### PR TITLE
Removing node and graph related concepts from the create.run specs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1527,42 +1527,6 @@
             "title": "Webhook",
             "description": "Webhook to call after LangGraph API call is done."
           },
-          "interrupt_before": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "*"
-                ]
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Interrupt Before",
-            "description": "Nodes to interrupt immediately before they get executed."
-          },
-          "interrupt_after": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "*"
-                ]
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            ],
-            "title": "Interrupt After",
-            "description": "Nodes to interrupt immediately after they get executed."
-          },
           "stream_mode": {
             "anyOf": [
               {


### PR DESCRIPTION
`interrupt_before` and `interrupt_after` are highly coupled with `nodes` concepts at the moment, which is not available in the agent protocol. Removing these fields from the schema. Also, `stream_subgraphs` using a `graph` lingo which is not appropriate. Renaming it as `stream_subagents`.

See how it renders on `OpenAPI.json` below:

<img width="1239" alt="doc_update_run_fields" src="https://github.com/user-attachments/assets/f5e57c1a-8083-456f-93e3-1032e92ee2be" />
