### PR TITLE
Remove tasks concept as it is highly related to graph/nodes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1814,42 +1814,6 @@
             "type": "array",
             "title": "Next"
           },
-          "tasks": {
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "title": "Task Id"
-                },
-                "name": {
-                  "type": "string",
-                  "title": "Node Name"
-                },
-                "error": {
-                  "type": "string",
-                  "title": "Error"
-                },
-                "interrupts": {
-                  "type": "array",
-                  "items": {}
-                },
-                "checkpoint": {
-                  "$ref": "#/components/schemas/CheckpointConfig",
-                  "title": "Checkpoint"
-                },
-                "state": {
-                  "$ref": "#/components/schemas/ThreadState"
-                }
-              },
-              "required": [
-                "id",
-                "name"
-              ]
-            },
-            "type": "array",
-            "title": "Tasks"
-          },
           "checkpoint": {
             "$ref": "#/components/schemas/CheckpointConfig",
             "title": "Checkpoint"


### PR DESCRIPTION
Tasks are related to operational states of the nodes/graph and this concept shouldn't exist in the agent-protocol spec yet. Removing it.

See how it looks on `OpenAPI.json` before and after below:
<img width="444" alt="before" src="https://github.com/user-attachments/assets/165379ec-3c8d-48ba-852c-3507f7ad763f" /> <img width="432" alt="after" src="https://github.com/user-attachments/assets/6c1ffd35-e501-410e-9a17-c5125b3d63d7" />
