### PR TITLE
Change Thread Copy 409 to 404

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Agent Protocol",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "tags": [
     {
@@ -323,8 +323,8 @@
               }
             }
           },
-          "409": {
-            "description": "Conflict",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/ap_server/main.py
+++ b/server/ap_server/main.py
@@ -9,7 +9,7 @@ from .routers import runs, stateless_runs, store, threads
 
 app = FastAPI(
     title="Agent Protocol",
-    version="0.1.1",
+    version="0.1.3",
 )
 
 app.include_router(runs.router)

--- a/server/ap_server/models.py
+++ b/server/ap_server/models.py
@@ -63,20 +63,16 @@ class Config(BaseModel):
 
 class StreamModeEnum(Enum):
     values = "values"
-    messages = "messages"
     messages_tuple = "messages-tuple"
     updates = "updates"
-    events = "events"
     debug = "debug"
     custom = "custom"
 
 
 class StreamMode(Enum):
     values = "values"
-    messages = "messages"
     messages_tuple = "messages-tuple"
     updates = "updates"
-    events = "events"
     debug = "debug"
     custom = "custom"
 
@@ -96,7 +92,7 @@ class RunCreateStateful(BaseModel):
         None,
         description="The assistant ID or graph name to run. If using graph name, will default to first assistant created from that graph.",
     )
-    input: Optional[Union[List[Dict[str, Any]], Dict[str, Any]]] = Field(
+    input: Optional[Union[Dict[str, Any], List, str, float, bool]] = Field(
         None, description="The input to the graph.", title="Input"
     )
     metadata: Optional[Dict[str, Any]] = Field(
@@ -106,9 +102,7 @@ class RunCreateStateful(BaseModel):
         None, description="The configuration for the assistant.", title="Config"
     )
     webhook: Optional[AnyUrl] = Field(
-        None,
-        description="Webhook to call after LangGraph API call is done.",
-        title="Webhook",
+        None, description="Webhook to call after run finishes.", title="Webhook"
     )
     stream_mode: Optional[Union[List[StreamModeEnum], StreamMode]] = Field(
         ["values"], description="The stream mode(s) to use.", title="Stream Mode"
@@ -122,9 +116,6 @@ class RunCreateStateful(BaseModel):
         "cancel",
         description="The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
         title="On Disconnect",
-    )
-    feedback_keys: Optional[List[str]] = Field(
-        None, description="Feedback keys to assign to run.", title="Feedback Keys"
     )
     multitask_strategy: Optional[MultitaskStrategy] = Field(
         "reject",
@@ -143,14 +134,6 @@ class RunCreateStateful(BaseModel):
     )
 
 
-class InterruptBefore(Enum):
-    field_ = "*"
-
-
-class InterruptAfter(Enum):
-    field_ = "*"
-
-
 class OnCompletion(Enum):
     delete = "delete"
     keep = "keep"
@@ -161,7 +144,7 @@ class RunCreateStateless(BaseModel):
         None,
         description="The assistant ID or graph name to run. If using graph name, will default to first assistant created from that graph.",
     )
-    input: Optional[Union[List[Dict[str, Any]], Dict[str, Any]]] = Field(
+    input: Optional[Union[Dict[str, Any], List, str, float, bool]] = Field(
         None, description="The input to the graph.", title="Input"
     )
     metadata: Optional[Dict[str, Any]] = Field(
@@ -171,19 +154,7 @@ class RunCreateStateless(BaseModel):
         None, description="The configuration for the assistant.", title="Config"
     )
     webhook: Optional[AnyUrl] = Field(
-        None,
-        description="Webhook to call after LangGraph API call is done.",
-        title="Webhook",
-    )
-    interrupt_before: Optional[Union[InterruptBefore, List[str]]] = Field(
-        None,
-        description="Nodes to interrupt immediately before they get executed.",
-        title="Interrupt Before",
-    )
-    interrupt_after: Optional[Union[InterruptAfter, List[str]]] = Field(
-        None,
-        description="Nodes to interrupt immediately after they get executed.",
-        title="Interrupt After",
+        None, description="Webhook to call after run finishes.", title="Webhook"
     )
     stream_mode: Optional[Union[List[StreamModeEnum], StreamMode]] = Field(
         ["values"], description="The stream mode(s) to use.", title="Stream Mode"
@@ -198,18 +169,10 @@ class RunCreateStateless(BaseModel):
         description="The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
         title="On Disconnect",
     )
-    feedback_keys: Optional[List[str]] = Field(
-        None, description="Feedback keys to assign to run.", title="Feedback Keys"
-    )
     multitask_strategy: Optional[MultitaskStrategy] = Field(
         "reject",
         description="Multitask strategy to use. Must be one of 'reject', 'interrupt', 'rollback', or 'enqueue'.",
         title="Multitask Strategy",
-    )
-    if_not_exists: Optional[IfNotExists] = Field(
-        "reject",
-        description="How to handle missing thread. Must be either 'reject' (raise error if missing), or 'create' (create new thread).",
-        title="If Not Exists",
     )
     after_seconds: Optional[int] = Field(
         None,

--- a/server/ap_server/routers/threads.py
+++ b/server/ap_server/routers/threads.py
@@ -99,7 +99,7 @@ def patch_thread_threads__thread_id__patch(
 @router.post(
     "/threads/{thread_id}/copy",
     response_model=Thread,
-    responses={"409": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
+    responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
     tags=["Threads"],
 )
 def copy_thread_post_threads__thread_id__copy_post(


### PR DESCRIPTION
Thread copy should return a 404 not found error if a thread_id is not present, rather than 409 conflict. A conflict error message is probably not needed, since the user does not pass a desired thread_id in the request