### PR TITLE
Consolidade thread state endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,10 @@ Endpoints:
 - [`POST /threads`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/POST/threads) - Create a thread.
 - [`POST /threads/search`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/POST/threads/search) - Search threads.
 - [`GET /threads/{thread_id}`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/GET/threads/%7Bthread_id%7D) - Get a thread.
-- [`GET /threads/{thread_id}/state`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/GET/threads/%7Bthread_id%7D/state) - Get the latest state of a thread.
-- [`POST /threads/{thread_id}/state`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/POST/threads/%7Bthread_id%7D/state) - Create a new revision of the thread’s state.
-- [`GET /threads/{thread_id}/history`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/GET/threads/%7Bthread_id%7D/history) - Browse past revisions of a thread’s state. Revisions are created by runs, or through the endpoint just above.
+- [`GET /threads/{thread_id}/history`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/GET/threads/%7Bthread_id%7D/history) - Browse past revisions of a thread’s state. Revisions are created by runs, or through the PATCH endpoint below.
 - [`POST /threads/{thread_id}/copy`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/POST/threads/%7Bthread_id%7D/copy) - Create an independent copy of a thread.
 - [`DELETE /threads/{thread_id}`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/DELETE/threads/%7Bthread_id%7D) - Delete a thread.
-- [`PATCH /threads/{thread_id}`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/PATCH/threads/%7Bthread_id%7D) - Update the metadata for a thread.
+- [`PATCH /threads/{thread_id}`](https://langchain-ai.github.io/agent-protocol/api.html#tag/threads/PATCH/threads/%7Bthread_id%7D) - Update a thread's values or metadata. Updating values creates a new revision in the thread's history.
 
 ## Stateless Runs: one-shot interactions
 

--- a/openapi.json
+++ b/openapi.json
@@ -306,126 +306,6 @@
         }
       }
     },
-    "/threads/{thread_id}/state": {
-      "get": {
-        "tags": [
-          "Threads"
-        ],
-        "summary": "Get Thread State",
-        "description": "Get state for a thread.\n\nThe latest state of the thread (i.e. latest checkpoint) is returned.",
-        "operationId": "get_latest_thread_state_threads__thread_id__state_get",
-        "parameters": [
-          {
-            "description": "The ID of the thread.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Thread Id",
-              "description": "The ID of the thread."
-            },
-            "name": "thread_id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ThreadState"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Threads"
-        ],
-        "summary": "Update Thread State",
-        "description": "Add state to a thread.",
-        "operationId": "update_thread_state_threads__thread_id__state_post",
-        "parameters": [
-          {
-            "description": "The ID of the thread.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Thread Id",
-              "description": "The ID of the thread."
-            },
-            "name": "thread_id",
-            "in": "path"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ThreadStateUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ThreadStateUpdateResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/threads/{thread_id}/history": {
       "get": {
         "tags": [
@@ -476,8 +356,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ThreadState"
                   },
-                  "type": "array",
-                  "title": "Response Get Thread History Threads  Thread Id  History Get"
+                  "type": "array"
                 }
               }
             }
@@ -2309,6 +2188,34 @@
         ],
         "title": "Thread"
       },
+      "ThreadState": {
+        "properties": {
+          "thread_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Thread Id",
+            "description": "The ID of the thread."
+          },
+          "checkpoint_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Checkpoint Id",
+            "description": "The ID of the checkpoint."
+          },
+          "values": {
+            "type": "object",
+            "title": "Values",
+            "description": "The current state of the thread."
+          }
+        },
+        "type": "object",
+        "required": [
+          "thread_id",
+          "checkpoint_id",
+          "values"
+        ],
+        "title": "ThreadState"
+      },
       "ThreadCreate": {
         "properties": {
           "thread_id": {
@@ -2343,119 +2250,16 @@
             "type": "object",
             "title": "Metadata",
             "description": "Metadata to merge with existing thread metadata."
+          },
+          "values": {
+            "type": "object",
+            "title": "Values",
+            "description": "Values to merge with existing thread values."
           }
         },
         "type": "object",
         "title": "ThreadPatch",
-        "description": "Payload for creating a thread."
-      },
-      "ThreadState": {
-        "properties": {
-          "values": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "object"
-              }
-            ],
-            "title": "Values"
-          },
-          "next": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Next"
-          },
-          "checkpoint": {
-            "$ref": "#/components/schemas/CheckpointConfig",
-            "title": "Checkpoint"
-          },
-          "metadata": {
-            "type": "object",
-            "title": "Metadata"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "parent_checkpoint": {
-            "type": "object",
-            "title": "Parent Checkpoint"
-          }
-        },
-        "type": "object",
-        "required": [
-          "values",
-          "next",
-          "checkpoint",
-          "metadata",
-          "created_at"
-        ],
-        "title": "ThreadState"
-      },
-      "ThreadStateUpdate": {
-        "properties": {
-          "values": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Values",
-            "description": "The values to update the state with."
-          },
-          "checkpoint": {
-            "$ref": "#/components/schemas/CheckpointConfig",
-            "title": "Checkpoint",
-            "description": "The checkpoint to update the state of."
-          }
-        },
-        "type": "object",
-        "title": "ThreadStateUpdate",
-        "description": "Payload for updating the state of a thread."
-      },
-      "ThreadStateUpdateResponse": {
-        "properties": {
-          "checkpoint": {
-            "type": "object",
-            "title": "Checkpoint"
-          }
-        },
-        "type": "object",
-        "title": "ThreadStateUpdateResponse",
-        "description": "Response for adding state to a thread."
-      },
-      "CheckpointConfig": {
-        "type": "object",
-        "title": "CheckpointConfig",
-        "description": "Checkpoint config.",
-        "properties": {
-          "thread_id": {
-            "type": "string",
-            "description": "Unique identifier for the thread associated with this checkpoint."
-          },
-          "checkpoint_ns": {
-            "type": "string",
-            "description": "Namespace for the checkpoint, used for organization and retrieval."
-          },
-          "checkpoint_id": {
-            "type": "string",
-            "description": "Optional unique identifier for the checkpoint itself."
-          },
-          "checkpoint_map": {
-            "type": "object",
-            "description": "Optional dictionary containing checkpoint-specific data."
-          }
-        }
+        "description": "Payload for updating a thread."
       },
       "StorePutRequest": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -2190,12 +2190,6 @@
       },
       "ThreadState": {
         "properties": {
-          "thread_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Thread Id",
-            "description": "The ID of the thread."
-          },
           "checkpoint_id": {
             "type": "string",
             "format": "uuid",

--- a/server/ap_server/models.py
+++ b/server/ap_server/models.py
@@ -261,7 +261,6 @@ class Thread(BaseModel):
 
 
 class ThreadState(BaseModel):
-    thread_id: UUID = Field(..., description="The ID of the thread.", title="Thread Id")
     checkpoint_id: UUID = Field(
         ..., description="The ID of the checkpoint.", title="Checkpoint Id"
     )

--- a/server/ap_server/models.py
+++ b/server/ap_server/models.py
@@ -260,6 +260,16 @@ class Thread(BaseModel):
     )
 
 
+class ThreadState(BaseModel):
+    thread_id: UUID = Field(..., description="The ID of the thread.", title="Thread Id")
+    checkpoint_id: UUID = Field(
+        ..., description="The ID of the checkpoint.", title="Checkpoint Id"
+    )
+    values: Dict[str, Any] = Field(
+        ..., description="The current state of the thread.", title="Values"
+    )
+
+
 class IfExists(Enum):
     raise_ = "raise"
     do_nothing = "do_nothing"
@@ -287,26 +297,8 @@ class ThreadPatch(BaseModel):
         description="Metadata to merge with existing thread metadata.",
         title="Metadata",
     )
-
-
-class ThreadStateUpdateResponse(BaseModel):
-    checkpoint: Optional[Dict[str, Any]] = Field(None, title="Checkpoint")
-
-
-class CheckpointConfig(BaseModel):
-    thread_id: Optional[str] = Field(
-        None,
-        description="Unique identifier for the thread associated with this checkpoint.",
-    )
-    checkpoint_ns: Optional[str] = Field(
-        None,
-        description="Namespace for the checkpoint, used for organization and retrieval.",
-    )
-    checkpoint_id: Optional[str] = Field(
-        None, description="Optional unique identifier for the checkpoint itself."
-    )
-    checkpoint_map: Optional[Dict[str, Any]] = Field(
-        None, description="Optional dictionary containing checkpoint-specific data."
+    values: Optional[Dict[str, Any]] = Field(
+        None, description="Values to merge with existing thread values.", title="Values"
     )
 
 
@@ -443,6 +435,10 @@ class ThreadsSearchPostResponse(RootModel[List[Thread]]):
     root: List[Thread] = Field(..., title="Response Search Threads Threads Search Post")
 
 
+class ThreadsThreadIdHistoryGetResponse(RootModel[List[ThreadState]]):
+    root: List[ThreadState]
+
+
 class ThreadsThreadIdRunsGetResponse(RootModel[List[Run]]):
     root: List[Run]
 
@@ -454,27 +450,3 @@ class Action(Enum):
 
 class Namespace(RootModel[List[str]]):
     root: List[str]
-
-
-class ThreadState(BaseModel):
-    values: Union[List[Dict[str, Any]], Dict[str, Any]] = Field(..., title="Values")
-    next: List[str] = Field(..., title="Next")
-    checkpoint: CheckpointConfig = Field(..., title="Checkpoint")
-    metadata: Dict[str, Any] = Field(..., title="Metadata")
-    created_at: str = Field(..., title="Created At")
-    parent_checkpoint: Optional[Dict[str, Any]] = Field(None, title="Parent Checkpoint")
-
-
-class ThreadStateUpdate(BaseModel):
-    values: Optional[Dict[str, Any]] = Field(
-        None, description="The values to update the state with.", title="Values"
-    )
-    checkpoint: Optional[CheckpointConfig] = Field(
-        None, description="The checkpoint to update the state of.", title="Checkpoint"
-    )
-
-
-class ThreadsThreadIdHistoryGetResponse(RootModel[List[ThreadState]]):
-    root: List[ThreadState] = Field(
-        ..., title="Response Get Thread History Threads  Thread Id  History Get"
-    )

--- a/server/ap_server/routers/threads.py
+++ b/server/ap_server/routers/threads.py
@@ -13,9 +13,6 @@ from ..models import (
     ThreadCreate,
     ThreadPatch,
     ThreadSearchRequest,
-    ThreadState,
-    ThreadStateUpdate,
-    ThreadStateUpdateResponse,
     ThreadsSearchPostResponse,
     ThreadsThreadIdHistoryGetResponse,
     UUID,
@@ -122,35 +119,5 @@ def get_thread_history_threads__thread_id__history_get(
 ) -> Union[ThreadsThreadIdHistoryGetResponse, ErrorResponse]:
     """
     Get Thread History
-    """
-    pass
-
-
-@router.get(
-    "/threads/{thread_id}/state",
-    response_model=ThreadState,
-    responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
-    tags=["Threads"],
-)
-def get_latest_thread_state_threads__thread_id__state_get(
-    thread_id: UUID,
-) -> Union[ThreadState, ErrorResponse]:
-    """
-    Get Thread State
-    """
-    pass
-
-
-@router.post(
-    "/threads/{thread_id}/state",
-    response_model=ThreadStateUpdateResponse,
-    responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
-    tags=["Threads"],
-)
-def update_thread_state_threads__thread_id__state_post(
-    thread_id: UUID, body: ThreadStateUpdate = ...
-) -> Union[ThreadStateUpdateResponse, ErrorResponse]:
-    """
-    Update Thread State
     """
     pass


### PR DESCRIPTION
- Remove get state endpoint for threads, as that's covered by get thread
- Move updating state to patch thread endpoint, remove update state endpoint
- Update history endpoint with a simpler schema