### PR TITLE
Change 200 responses to 204 for Deletes and Cancel, add missing Store 404 responses

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Agent Protocol",
-    "version": "0.1.51"
+    "version": "0.1.6"
   },
   "tags": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Agent Protocol",
-    "version": "0.1.5"
+    "version": "0.1.51"
   },
   "tags": [
     {
@@ -517,13 +517,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          "204": {
+            "description": "Success"
           },
           "404": {
             "description": "Not Found",
@@ -1014,13 +1009,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          "204": {
+            "description": "Success"
           },
           "404": {
             "description": "Not Found",
@@ -1236,13 +1226,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          "204": {
+            "description": "Success"
           },
           "404": {
             "description": "Not Found",
@@ -1503,6 +1488,16 @@
           "204": {
             "description": "Success"
           },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1555,6 +1550,16 @@
           },
           "400": {
             "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/ap_server/main.py
+++ b/server/ap_server/main.py
@@ -9,7 +9,7 @@ from .routers import agents, runs, stateless_runs, store, threads
 
 app = FastAPI(
     title="Agent Protocol",
-    version="0.1.5",
+    version="0.1.51",
 )
 
 app.include_router(agents.router)

--- a/server/ap_server/main.py
+++ b/server/ap_server/main.py
@@ -9,7 +9,7 @@ from .routers import agents, runs, stateless_runs, store, threads
 
 app = FastAPI(
     title="Agent Protocol",
-    version="0.1.51",
+    version="0.1.6",
 )
 
 app.include_router(agents.router)

--- a/server/ap_server/routers/runs.py
+++ b/server/ap_server/routers/runs.py
@@ -109,13 +109,14 @@ def get_run_http_threads__thread_id__runs__run_id__get(
 
 @router.delete(
     "/threads/{thread_id}/runs/{run_id}",
-    response_model=Any,
+    response_model=None,
+    status_code=204,
     responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
     tags=["Runs"],
 )
 def delete_run_threads__thread_id__runs__run_id__delete(
     thread_id: UUID, run_id: UUID = ...
-) -> Union[Any, ErrorResponse]:
+) -> Optional[ErrorResponse]:
     """
     Delete Run
     """
@@ -124,7 +125,8 @@ def delete_run_threads__thread_id__runs__run_id__delete(
 
 @router.post(
     "/threads/{thread_id}/runs/{run_id}/cancel",
-    response_model=Any,
+    response_model=None,
+    status_code=204,
     responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
     tags=["Runs"],
 )
@@ -133,7 +135,7 @@ def cancel_run_http_threads__thread_id__runs__run_id__cancel_post(
     run_id: UUID = ...,
     wait: Optional[bool] = False,
     action: Optional[Action] = "interrupt",
-) -> Union[Any, ErrorResponse]:
+) -> Optional[ErrorResponse]:
     """
     Cancel Run
     """

--- a/server/ap_server/routers/store.py
+++ b/server/ap_server/routers/store.py
@@ -27,6 +27,7 @@ router = APIRouter(tags=["Store"])
 @router.put(
     "/store/items",
     response_model=None,
+    status_code=204,
     responses={"422": {"model": ErrorResponse}},
     tags=["Store"],
 )
@@ -40,7 +41,8 @@ def put_item(body: StorePutRequest) -> Optional[ErrorResponse]:
 @router.delete(
     "/store/items",
     response_model=None,
-    responses={"422": {"model": ErrorResponse}},
+    status_code=204,
+    responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
     tags=["Store"],
 )
 def delete_item(body: StoreDeleteRequest) -> Optional[ErrorResponse]:
@@ -53,7 +55,11 @@ def delete_item(body: StoreDeleteRequest) -> Optional[ErrorResponse]:
 @router.get(
     "/store/items",
     response_model=Item,
-    responses={"400": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
+    responses={
+        "400": {"model": ErrorResponse},
+        "404": {"model": ErrorResponse},
+        "422": {"model": ErrorResponse},
+    },
     tags=["Store"],
 )
 def get_item(

--- a/server/ap_server/routers/threads.py
+++ b/server/ap_server/routers/threads.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from ..models import (
-    Any,
     ErrorResponse,
     Optional,
     Thread,
@@ -65,13 +64,14 @@ def get_thread_threads__thread_id__get(thread_id: UUID) -> Union[Thread, ErrorRe
 
 @router.delete(
     "/threads/{thread_id}",
-    response_model=Any,
+    response_model=None,
+    status_code=204,
     responses={"404": {"model": ErrorResponse}, "422": {"model": ErrorResponse}},
     tags=["Threads"],
 )
 def delete_thread_threads__thread_id__delete(
     thread_id: UUID,
-) -> Union[Any, ErrorResponse]:
+) -> Optional[ErrorResponse]:
     """
     Delete Thread
     """

--- a/tooling/Makefile
+++ b/tooling/Makefile
@@ -6,6 +6,7 @@ gen-server:
 	sed -i '' 's|Action1|Action|g' ../server/ap_server/routers/*.py
 	sed -i '' 's|from fastapi import APIRouter|from typing import Annotated\n\nfrom fastapi import APIRouter, Query|g' ../server/ap_server/routers/store.py
 	sed -i '' 's|namespace: Optional\[Namespace\] = None|namespace: Annotated\[list\[str\] \| None, Query\(\)\] = None|g' ../server/ap_server/routers/store.py
+	sed -i '' 's|response_model=None,|response_model=None, status_code=204,|g' ../server/ap_server/routers/*.py
 	poetry run ruff format ../server/ap_server
 	touch ../server/ap_server/__init__.py
 	touch ../server/ap_server/routers/__init__.py


### PR DESCRIPTION
- Delete and Cancel endpoints for Threads and Runs had 200 response rather than 204 like the Store endpoints, aligned these to 204
- Fastapi-codegen doesn't create 204 status codes in the generated docs, updated the tooling makefile to patch this when generating the server
- Store endpoints for GET and DELETE item were missing 404 error response