### PR TITLE
Add capabilities map for Agent

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1693,12 +1693,26 @@
             "type": "object",
             "title": "Metadata",
             "description": "The agent metadata."
+          },
+          "capabilities": {
+            "type": "object",
+            "title": "Agent Capabilities",
+            "description": "Describes which protocol features the agent supports. In addition to the standard capabilities (prefixed with ap.), implementations can declare custom capabilities, named in reverse domain notation (eg. com.example.some.capability).",
+            "properties": {
+              "ap.io.messages": {
+                "type": "boolean",
+                "title": "Messages",
+                "description": "Whether the agent supports Messages as input/output/state. If true, the agent uses the `messages` key in threads/runs endpoints."
+              }
+            },
+            "additionalProperties": true
           }
         },
         "type": "object",
         "required": [
           "agent_id",
-          "name"
+          "name",
+          "capabilities"
         ],
         "title": "Agent"
       },
@@ -1845,7 +1859,15 @@
               }
             ],
             "title": "Input",
-            "description": "The input to the graph."
+            "description": "The input to the agent."
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
+            "title": "Messages",
+            "description": "The messages to pass as input to the agent."
           },
           "metadata": {
             "type": "object",
@@ -2015,7 +2037,15 @@
               }
             ],
             "title": "Input",
-            "description": "The input to the graph."
+            "description": "The input to the agent."
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
+            "title": "Messages",
+            "description": "The messages to pass an input to the agent."
           },
           "metadata": {
             "type": "object",

--- a/server/ap_server/models.py
+++ b/server/ap_server/models.py
@@ -18,6 +18,18 @@ from pydantic import (
 )
 
 
+class Capabilities(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+    )
+    ap_io_messages: Optional[bool] = Field(
+        None,
+        alias="ap.io.messages",
+        description="Whether the agent supports Messages as input/output/state. If true, the agent uses the `messages` key in threads/runs endpoints.",
+        title="Messages",
+    )
+
+
 class Agent(BaseModel):
     agent_id: str = Field(..., description="The ID of the agent.", title="Agent Id")
     name: str = Field(..., description="The name of the agent", title="Agent Name")
@@ -26,6 +38,11 @@ class Agent(BaseModel):
     )
     metadata: Optional[Dict[str, Any]] = Field(
         None, description="The agent metadata.", title="Metadata"
+    )
+    capabilities: Capabilities = Field(
+        ...,
+        description="Describes which protocol features the agent supports. In addition to the standard capabilities (prefixed with ap.), implementations can declare custom capabilities, named in reverse domain notation (eg. com.example.some.capability).",
+        title="Agent Capabilities",
     )
 
 
@@ -128,100 +145,9 @@ class IfNotExists(Enum):
     reject = "reject"
 
 
-class RunCreateStateful(BaseModel):
-    agent_id: Optional[str] = Field(
-        None,
-        description="The agent ID to run. If not provided will use the default agent for this service.",
-        title="Agent Id",
-    )
-    input: Optional[Union[Dict[str, Any], List, str, float, bool]] = Field(
-        None, description="The input to the graph.", title="Input"
-    )
-    metadata: Optional[Dict[str, Any]] = Field(
-        None, description="Metadata to assign to the run.", title="Metadata"
-    )
-    config: Optional[Config] = Field(
-        None, description="The configuration for the agent.", title="Config"
-    )
-    webhook: Optional[AnyUrl] = Field(
-        None, description="Webhook to call after run finishes.", title="Webhook"
-    )
-    stream_mode: Optional[Union[List[StreamModeEnum], StreamMode]] = Field(
-        ["values"], description="The stream mode(s) to use.", title="Stream Mode"
-    )
-    stream_subgraphs: Optional[bool] = Field(
-        False,
-        description="Whether to stream output from subgraphs.",
-        title="Stream Subgraphs",
-    )
-    on_disconnect: Optional[OnDisconnect] = Field(
-        "cancel",
-        description="The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
-        title="On Disconnect",
-    )
-    multitask_strategy: Optional[MultitaskStrategy] = Field(
-        "reject",
-        description="Multitask strategy to use. Must be one of 'reject', 'interrupt', 'rollback', or 'enqueue'.",
-        title="Multitask Strategy",
-    )
-    if_not_exists: Optional[IfNotExists] = Field(
-        "reject",
-        description="How to handle missing thread. Must be either 'reject' (raise error if missing), or 'create' (create new thread).",
-        title="If Not Exists",
-    )
-    after_seconds: Optional[int] = Field(
-        None,
-        description="The number of seconds to wait before starting the run. Use to schedule future runs.",
-        title="After Seconds",
-    )
-
-
 class OnCompletion(Enum):
     delete = "delete"
     keep = "keep"
-
-
-class RunCreateStateless(BaseModel):
-    agent_id: Optional[str] = Field(
-        None,
-        description="The agent ID to run. If not provided will use the default agent for this service.",
-        title="Agent Id",
-    )
-    input: Optional[Union[Dict[str, Any], List, str, float, bool]] = Field(
-        None, description="The input to the graph.", title="Input"
-    )
-    metadata: Optional[Dict[str, Any]] = Field(
-        None, description="Metadata to assign to the run.", title="Metadata"
-    )
-    config: Optional[Config] = Field(
-        None, description="The configuration for the agent.", title="Config"
-    )
-    webhook: Optional[AnyUrl] = Field(
-        None, description="Webhook to call after run finishes.", title="Webhook"
-    )
-    stream_mode: Optional[Union[List[StreamModeEnum], StreamMode]] = Field(
-        ["values"], description="The stream mode(s) to use.", title="Stream Mode"
-    )
-    on_completion: Optional[OnCompletion] = Field(
-        "delete",
-        description="Whether to delete or keep the thread created for a stateless run. Must be one of 'delete' or 'keep'.",
-        title="On Completion",
-    )
-    on_disconnect: Optional[OnDisconnect] = Field(
-        "cancel",
-        description="The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
-        title="On Disconnect",
-    )
-    multitask_strategy: Optional[MultitaskStrategy] = Field(
-        "reject",
-        description="Multitask strategy to use. Must be one of 'reject', 'interrupt', 'rollback', or 'enqueue'.",
-        title="Multitask Strategy",
-    )
-    after_seconds: Optional[int] = Field(
-        None,
-        description="The number of seconds to wait before starting the run. Use to schedule future runs.",
-        title="After Seconds",
-    )
 
 
 class Status1(Enum):
@@ -449,6 +375,59 @@ class Namespace(RootModel[List[str]]):
     root: List[str]
 
 
+class RunCreateStateful(BaseModel):
+    agent_id: Optional[str] = Field(
+        None,
+        description="The agent ID to run. If not provided will use the default agent for this service.",
+        title="Agent Id",
+    )
+    input: Optional[Union[Dict[str, Any], List, str, float, bool]] = Field(
+        None, description="The input to the agent.", title="Input"
+    )
+    messages: Optional[List[Message]] = Field(
+        None,
+        description="The messages to pass as input to the agent.",
+        title="Messages",
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None, description="Metadata to assign to the run.", title="Metadata"
+    )
+    config: Optional[Config] = Field(
+        None, description="The configuration for the agent.", title="Config"
+    )
+    webhook: Optional[AnyUrl] = Field(
+        None, description="Webhook to call after run finishes.", title="Webhook"
+    )
+    stream_mode: Optional[Union[List[StreamModeEnum], StreamMode]] = Field(
+        ["values"], description="The stream mode(s) to use.", title="Stream Mode"
+    )
+    stream_subgraphs: Optional[bool] = Field(
+        False,
+        description="Whether to stream output from subgraphs.",
+        title="Stream Subgraphs",
+    )
+    on_disconnect: Optional[OnDisconnect] = Field(
+        "cancel",
+        description="The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
+        title="On Disconnect",
+    )
+    multitask_strategy: Optional[MultitaskStrategy] = Field(
+        "reject",
+        description="Multitask strategy to use. Must be one of 'reject', 'interrupt', 'rollback', or 'enqueue'.",
+        title="Multitask Strategy",
+    )
+    if_not_exists: Optional[IfNotExists] = Field(
+        "reject",
+        description="How to handle missing thread. Must be either 'reject' (raise error if missing), or 'create' (create new thread).",
+        title="If Not Exists",
+    )
+    after_seconds: Optional[int] = Field(
+        None,
+        description="The number of seconds to wait before starting the run. Use to schedule future runs.",
+        title="After Seconds",
+    )
+
+
 class RunWaitResponse(BaseModel):
     run: Optional[Run] = Field(None, description="The run information.", title="Run")
     values: Optional[Dict[str, Any]] = Field(
@@ -456,6 +435,54 @@ class RunWaitResponse(BaseModel):
     )
     messages: Optional[List[Message]] = Field(
         None, description="The messages returned by the run.", title="Messages"
+    )
+
+
+class RunCreateStateless(BaseModel):
+    agent_id: Optional[str] = Field(
+        None,
+        description="The agent ID to run. If not provided will use the default agent for this service.",
+        title="Agent Id",
+    )
+    input: Optional[Union[Dict[str, Any], List, str, float, bool]] = Field(
+        None, description="The input to the agent.", title="Input"
+    )
+    messages: Optional[List[Message]] = Field(
+        None,
+        description="The messages to pass an input to the agent.",
+        title="Messages",
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None, description="Metadata to assign to the run.", title="Metadata"
+    )
+    config: Optional[Config] = Field(
+        None, description="The configuration for the agent.", title="Config"
+    )
+    webhook: Optional[AnyUrl] = Field(
+        None, description="Webhook to call after run finishes.", title="Webhook"
+    )
+    stream_mode: Optional[Union[List[StreamModeEnum], StreamMode]] = Field(
+        ["values"], description="The stream mode(s) to use.", title="Stream Mode"
+    )
+    on_completion: Optional[OnCompletion] = Field(
+        "delete",
+        description="Whether to delete or keep the thread created for a stateless run. Must be one of 'delete' or 'keep'.",
+        title="On Completion",
+    )
+    on_disconnect: Optional[OnDisconnect] = Field(
+        "cancel",
+        description="The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
+        title="On Disconnect",
+    )
+    multitask_strategy: Optional[MultitaskStrategy] = Field(
+        "reject",
+        description="Multitask strategy to use. Must be one of 'reject', 'interrupt', 'rollback', or 'enqueue'.",
+        title="Multitask Strategy",
+    )
+    after_seconds: Optional[int] = Field(
+        None,
+        description="The number of seconds to wait before starting the run. Use to schedule future runs.",
+        title="After Seconds",
     )
 
 


### PR DESCRIPTION
- Supports both built-in well-known protocol capabilities as well as custom, implementation-specific capabilities
- Add messages key to run input payload