### PR TITLE
feat(streaming): add new streaming primitives

### DIFF
--- a/.github/actions/uv_setup/action.yml
+++ b/.github/actions/uv_setup/action.yml
@@ -1,0 +1,18 @@
+# Helper to set up Python and uv
+
+name: uv-install
+description: Set up Python and uv
+
+inputs:
+  python-version:
+    description: Python version, supporting MAJOR.MINOR only
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv and set the python version
+      uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      with:
+        version: "0.5.25"
+        python-version: ${{ inputs.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-name: release
-run-name: Release langchain-protocol by @${{ github.actor }}
+name: release streaming protocol
+run-name: Release streaming-protocol by @${{ github.actor }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: release
+run-name: Release langchain-protocol by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dangerous-nonmain-release:
+        required: false
+        type: boolean
+        default: false
+        description: "Release from a non-main branch (danger!)"
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+
+defaults:
+  run:
+    working-directory: py
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/main' || inputs.dangerous-nonmain-release
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.check-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python + uv
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build project for distribution
+        run: uv build
+
+      - name: Upload build
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: dist
+          path: py/dist/
+
+      - name: Read version
+        id: check-version
+        shell: python
+        run: |
+          import os
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"version={data['project']['version']}\n")
+
+  smoke-test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python + uv
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: ${{ runner.temp }}/dist/
+
+      - name: Install built wheel and import
+        working-directory: ${{ runner.temp }}
+        run: |
+          uv venv
+          VIRTUAL_ENV=.venv uv pip install dist/*.whl
+          uv run python -c "import langchain_protocol; print(dir(langchain_protocol))"
+
+  publish:
+    needs:
+      - build
+      - smoke-test
+    runs-on: ubuntu-latest
+    permissions:
+      # Trusted publishing to PyPI:
+      # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: py/dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        with:
+          packages-dir: py/dist/
+          verbose: true
+          print-hash: true
+          attestations: false
+
+  mark-release:
+    needs:
+      - build
+      - smoke-test
+      - publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: py/dist/
+
+      - name: Create Release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+        with:
+          artifacts: "py/dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          generateReleaseNotes: true
+          tag: langchain-protocol==${{ needs.build.outputs.version }}
+          commit: ${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+streaming/node_modules

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Agent Protocol also defines a thread-centric streaming protocol for observing an
 
 The streaming schema and generated bindings live in [`streaming/`](./streaming/). The CDDL schema is the source of truth, with generated TypeScript and Python bindings available for clients and implementations that want strongly typed protocol payloads.
 
+Streaming endpoints:
+
+- `POST /threads/{thread_id}/stream` opens a filtered Server-Sent Events stream for a thread. The request body selects channels, namespace prefixes, optional depth, and optional replay position.
+- `GET /threads/{thread_id}/stream` upgrades to a WebSocket connection for bidirectional streaming. Once upgraded, commands, command responses, and unsolicited events share the same connection.
+- `POST /threads/{thread_id}/commands` sends a streaming protocol command over HTTP and returns the correlated command response.
+
 ## Agent Protocol in Action
 
 Below are a few illustrative “user journeys” in [Hurl](https://hurl.dev) format, each showing a common sequence of API calls against your Agent Protocol service (listening at localhost:8000, no auth required).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent Protocol is our attempt at codifying the framework-agnostic APIs that are needed to serve LLM agents in production. This document explains the purpose of the protocol and makes the case for each of the endpoints in the spec. We finish by listing some roadmap items for the future.
 
-See the full OpenAPI docs [here](https://langchain-ai.github.io/agent-protocol/api.html) and the JSON spec [here](https://langchain-ai.github.io/agent-protocol/openapi.json).
+See the [full OpenAPI docs](https://langchain-ai.github.io/agent-protocol/api.html) and the [JSON spec](https://langchain-ai.github.io/agent-protocol/openapi.json).
 
 [LangGraph Platform](https://www.langchain.com/pricing-langgraph-platform) implements a superset of this protocol, but we very much welcome other implementations from the community.
 
@@ -10,6 +10,7 @@ See the full OpenAPI docs [here](https://langchain-ai.github.io/agent-protocol/a
 
 - [Agent Protocol OpenAPI Docs](https://langchain-ai.github.io/agent-protocol/api.html)
 - [Agent Protocol JSON Spec](https://langchain-ai.github.io/agent-protocol/openapi.json)
+- [Agent Streaming Protocol](./streaming/) - streaming primitives, CDDL schema, and generated Python/TypeScript bindings for live agent execution
 - [Agent Protocol Python Server Stubs](./server/) - a Python server, using Pydantic V2 and FastAPI, auto-generated from the OpenAPI spec
 - [LangGraph.js API](https://github.com/langchain-ai/langgraphjs-api/tree/main/libs/langgraph-api) - an open-source implementation of this protocol, for LangGraph.js agents, using in-memory storage
 - [LangGraph Platform](https://www.langchain.com/pricing-langgraph-platform) - a commercial platform that implements a superset of this protocol for deploying any LLM agent in production
@@ -122,6 +123,12 @@ Endpoints:
 ## Messages
 
 Messages have emerged as a core primitive in dealing with LLMs, and as such we have first-class support for messages in Agent Protocol. This is in addition to completely customizable input/output schemas for agents. We define a Message spec, which is a subset of the message formats supported by major LLM providers, such as OpenAI and Anthropic. In all endpoints that expose thread values, there is also a separate `messages` field, which agents can optionally implement.
+
+## Streaming Primitives
+
+Agent Protocol also defines a thread-centric streaming protocol for observing and controlling live agent executions. The streaming primitives cover transport framing, filtered subscriptions, replay, namespaces for nested agents, content-block message deltas, tool lifecycle events, run lifecycle events, human-in-the-loop input, state snapshots, updates, checkpoints, tasks, and custom events.
+
+The streaming schema and generated bindings live in [`streaming/`](./streaming/). The CDDL schema is the source of truth, with generated TypeScript and Python bindings available for clients and implementations that want strongly typed protocol payloads.
 
 ## Agent Protocol in Action
 
@@ -263,5 +270,5 @@ HTTP/1.1 204
 - Add detailed specification for each stream mode (currently this is left open to the implementer)
 - Add Store endpoint to perform a vector search over memory entries
 - Add param for `POST /threads/{thread_id}/runs/{run_id}/stream` to replay events since `event-id` before streaming new events
-- Add param to `POST /threads/{thread_id}/runs ` to optionally allow concurrent runs on the same thread (current spec makes this forbidden)
+- Add param to `POST /threads/{thread_id}/runs` to optionally allow concurrent runs on the same thread (current spec makes this forbidden)
 - (Open an issue and let us know what else should be here!)

--- a/openapi.json
+++ b/openapi.json
@@ -22,6 +22,10 @@
       "description": "Background runs are runs that do not run synchronously during the request that created them. They can be managed, cancelled, streamed and waited with these endpoints."
     },
     {
+      "name": "Streaming",
+      "description": "Thread-scoped streaming endpoints for filtered event streams, command delivery, and WebSocket transport."
+    },
+    {
       "name": "Store",
       "description": "Store is an API for managing persistent key-value store (long-term memory) that is available from any thread."
     }
@@ -1094,6 +1098,181 @@
         }
       }
     },
+    "/threads/{thread_id}/stream": {
+      "post": {
+        "tags": ["Streaming"],
+        "summary": "Open Thread SSE Stream",
+        "description": "Open a connection-scoped Server-Sent Events stream for a thread. The request body selects channels, namespace prefixes, optional namespace depth, and an optional sequence number to replay buffered events after. Closing the HTTP connection unsubscribes from this stream.",
+        "operationId": "open_thread_sse_stream",
+        "parameters": [
+          {
+            "description": "The ID of the thread whose events should be streamed.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Thread Id",
+              "description": "The ID of the thread whose events should be streamed."
+            },
+            "name": "thread_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventStreamRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A filtered stream of protocol events in SSE format.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "The server sends streaming protocol events as Server-Sent Events. Each event payload is a StreamingEvent JSON object."
+                },
+                "example": "id: evt_123\nevent: messages\ndata: {\"type\":\"event\",\"eventId\":\"evt_123\",\"seq\":43,\"method\":\"messages\",\"params\":{\"namespace\":[],\"timestamp\":1710000000000,\"data\":{\"event\":\"message-start\",\"role\":\"ai\",\"id\":\"msg_123\"}}}\n\n"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Streaming"],
+        "summary": "Open Thread WebSocket Stream",
+        "description": "Upgrade to a WebSocket connection for a thread. After the connection is upgraded, clients send streaming protocol commands in-band and receive command responses plus unsolicited events on the same connection. Use `subscription.subscribe`, `subscription.unsubscribe`, and `subscription.reconnect` to manage event filters on the WebSocket.",
+        "operationId": "open_thread_websocket_stream",
+        "parameters": [
+          {
+            "description": "The ID of the thread to open over WebSocket.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Thread Id",
+              "description": "The ID of the thread to open over WebSocket."
+            },
+            "name": "thread_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "101": {
+            "description": "Switching Protocols. The connection is upgraded to WebSocket and uses the streaming protocol message framing."
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/commands": {
+      "post": {
+        "tags": ["Streaming"],
+        "summary": "Send Thread Streaming Command",
+        "description": "Send a streaming protocol command to a thread over HTTP. This endpoint is the request/response companion to the SSE event stream and supports commands such as `run.input`, `input.respond`, `input.inject`, `state.get`, `state.listCheckpoints`, and `state.fork`.",
+        "operationId": "send_thread_streaming_command",
+        "parameters": [
+          {
+            "description": "The ID of the thread that should receive the command.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Thread Id",
+              "description": "The ID of the thread that should receive the command."
+            },
+            "name": "thread_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamingCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Command response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamingCommandResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/store/items": {
       "put": {
         "tags": ["Store"],
@@ -1392,6 +1571,211 @@
         "required": ["agent_id", "input_schema", "output_schema"],
         "title": "AgentSchema",
         "description": "Defines the structure and properties of an agent."
+      },
+      "StreamingChannel": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "values",
+              "updates",
+              "messages",
+              "tools",
+              "lifecycle",
+              "input",
+              "checkpoints",
+              "tasks",
+              "custom"
+            ]
+          },
+          {
+            "type": "string",
+            "pattern": "^custom:.+"
+          }
+        ],
+        "title": "StreamingChannel",
+        "description": "A subscribable streaming channel. Namespaced custom channels use the `custom:*` form."
+      },
+      "StreamingNamespace": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "title": "StreamingNamespace",
+        "description": "Hierarchical path identifying a position in the agent tree. The empty array identifies the root agent."
+      },
+      "EventStreamRequest": {
+        "type": "object",
+        "required": ["channels"],
+        "properties": {
+          "channels": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/StreamingChannel"
+            },
+            "description": "Channels to include in this event stream."
+          },
+          "namespaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StreamingNamespace"
+            },
+            "description": "Namespace prefixes to include. Omit to receive matching events from all namespaces."
+          },
+          "depth": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum depth below each namespace prefix."
+          },
+          "since": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Replay buffered matching events after this monotonic sequence number, then switch to live delivery."
+          }
+        },
+        "additionalProperties": true,
+        "title": "EventStreamRequest",
+        "description": "Request body for a connection-scoped SSE event stream."
+      },
+      "StreamingCommand": {
+        "type": "object",
+        "required": ["id", "method"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Client-assigned command ID used to correlate the command response."
+          },
+          "method": {
+            "type": "string",
+            "description": "Streaming protocol command method, such as `run.input`, `subscription.subscribe`, `input.respond`, or `state.get`."
+          },
+          "params": {
+            "type": "object",
+            "description": "Command parameters. Shape depends on the command method.",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true,
+        "title": "StreamingCommand",
+        "description": "Client-to-server command in the streaming protocol."
+      },
+      "StreamingSuccessResponse": {
+        "type": "object",
+        "required": ["type", "id", "result"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "success"
+          },
+          "id": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "ID of the command this response belongs to."
+          },
+          "result": {
+            "type": "object",
+            "description": "Command result. Shape depends on the command method.",
+            "additionalProperties": true
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "appliedThroughSeq": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Latest event sequence number applied before this response."
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true,
+        "title": "StreamingSuccessResponse"
+      },
+      "StreamingErrorResponse": {
+        "type": "object",
+        "required": ["type", "id", "error", "message"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "error"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ID of the command this response belongs to, or null if the command could not be correlated."
+          },
+          "error": {
+            "type": "string",
+            "description": "Streaming protocol error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "stacktrace": {
+            "type": "string",
+            "description": "Optional stack trace for debugging."
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true,
+        "title": "StreamingErrorResponse"
+      },
+      "StreamingCommandResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/StreamingSuccessResponse"
+          },
+          {
+            "$ref": "#/components/schemas/StreamingErrorResponse"
+          }
+        ],
+        "title": "StreamingCommandResponse",
+        "description": "Server response to a streaming protocol command."
+      },
+      "StreamingEvent": {
+        "type": "object",
+        "required": ["type", "method", "params"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "event"
+          },
+          "eventId": {
+            "type": "string",
+            "description": "Unique event ID used for reconnection. Maps to the SSE `id:` field."
+          },
+          "seq": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Monotonic sequence number for ordering and replay."
+          },
+          "method": {
+            "type": "string",
+            "description": "Event method. Most events use the channel name, while some event families use a more specific method such as `input.requested`."
+          },
+          "params": {
+            "type": "object",
+            "description": "Event parameters, including namespace, timestamp, and channel-specific data.",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true,
+        "title": "StreamingEvent",
+        "description": "Server-to-client event in the streaming protocol."
       },
       "RunStatus": {
         "type": "string",

--- a/streaming/README.md
+++ b/streaming/README.md
@@ -42,8 +42,8 @@ WebSocket, and in-process transports.
 
 SSE uses connection-scoped subscriptions:
 
-- `POST /v2/threads/:thread_id/events` opens a filtered event stream.
-- `POST /v2/threads/:thread_id/commands` sends a JSON command and receives a
+- `POST /threads/:thread_id/stream` opens a filtered event stream.
+- `POST /threads/:thread_id/commands` sends a JSON command and receives a
   JSON response.
 
 The `events` request body is an `EventStreamRequest`:
@@ -66,12 +66,18 @@ checkpoint updates.
 
 WebSocket uses in-band commands over a single full-duplex connection:
 
+- `GET /threads/:thread_id/stream` upgrades to the thread WebSocket.
 - `subscription.subscribe` creates a filtered subscription.
 - `subscription.unsubscribe` removes a subscription.
 - `subscription.reconnect` restores subscriptions and requests missed events.
 
 Subscriptions persist across run boundaries and are removed explicitly or when
 the WebSocket closes.
+
+Once the upgrade succeeds, the WebSocket uses the same top-level message framing
+described below. Clients send `Command` objects, and servers send
+`CommandResponse`, `ErrorResponse`, and unsolicited `Event` objects on the same
+connection.
 
 ## Top-Level Framing
 

--- a/streaming/README.md
+++ b/streaming/README.md
@@ -1,0 +1,394 @@
+# Agent Streaming Protocol
+
+This directory contains the Agent Protocol streaming specification and generated
+language bindings:
+
+- `protocol.cddl`: the source of truth for the wire format.
+- `js/`: generated TypeScript types for protocol payloads.
+- `py/`: generated Python `TypedDict` and `Literal` types for protocol payloads.
+
+The streaming protocol is a thread-centric event and command protocol for
+observing and controlling long-running agent executions. It is designed for
+multiple transports, supports filtered subscriptions, and makes streamed model
+output, tool activity, graph state, checkpoints, lifecycle status, and
+human-in-the-loop interactions available through a common envelope.
+
+## Design Goals
+
+The protocol is built around a few stable primitives:
+
+- Threads are the durable routing key for commands, events, state, checkpoints,
+  and run history.
+- Connections are ephemeral transport scopes. Multiple clients can observe the
+  same thread concurrently with different filters.
+- Channels partition the event stream by concern, so clients can subscribe only
+  to the data they need.
+- Namespaces identify positions in an agent or graph tree, allowing clients to
+  subscribe to a root agent, a subgraph, or a bounded depth below either.
+- Content blocks are the universal carrier for model output deltas, including
+  text, reasoning, tool calls, server-side tool calls, multimodal data, and
+  provider-specific extensions.
+- Events carry explicit lifecycle boundaries. Clients do not need to infer when
+  a message, content block, tool call, run, or subgraph starts and finishes.
+- Replay is sequence-based, allowing clients to reconnect and request missed
+  events from the server's event buffer.
+
+## Transport Model
+
+The CDDL schema defines a single payload model that can be used over SSE/HTTP,
+WebSocket, and in-process transports.
+
+### SSE/HTTP
+
+SSE uses connection-scoped subscriptions:
+
+- `POST /v2/threads/:thread_id/events` opens a filtered event stream.
+- `POST /v2/threads/:thread_id/commands` sends a JSON command and receives a
+  JSON response.
+
+The `events` request body is an `EventStreamRequest`:
+
+```json
+{
+  "channels": ["messages", "updates", "lifecycle"],
+  "namespaces": [[]],
+  "depth": 2,
+  "since": 123
+}
+```
+
+Each SSE connection is its own subscription. Closing the connection unsubscribes
+from that stream. A client may open multiple event streams for the same thread,
+for example one stream for low-latency model tokens and another for state or
+checkpoint updates.
+
+### WebSocket
+
+WebSocket uses in-band commands over a single full-duplex connection:
+
+- `subscription.subscribe` creates a filtered subscription.
+- `subscription.unsubscribe` removes a subscription.
+- `subscription.reconnect` restores subscriptions and requests missed events.
+
+Subscriptions persist across run boundaries and are removed explicitly or when
+the WebSocket closes.
+
+## Top-Level Framing
+
+Client-to-server messages are commands:
+
+```json
+{
+  "id": 1,
+  "method": "run.input",
+  "params": {
+    "assistantId": "agent",
+    "input": {
+      "messages": [{ "role": "user", "content": "Hello" }]
+    }
+  }
+}
+```
+
+Server-to-client messages are either command responses, error responses, or
+events.
+
+Successful responses include the original command `id` and a typed `result`:
+
+```json
+{
+  "type": "success",
+  "id": 1,
+  "result": {
+    "runId": "run_123"
+  },
+  "meta": {
+    "appliedThroughSeq": 42
+  }
+}
+```
+
+Error responses include the original command `id` when available:
+
+```json
+{
+  "type": "error",
+  "id": 1,
+  "error": "invalid_argument",
+  "message": "assistantId is required"
+}
+```
+
+Events are unsolicited server pushes:
+
+```json
+{
+  "type": "event",
+  "eventId": "evt_123",
+  "seq": 43,
+  "method": "messages",
+  "params": {
+    "namespace": [],
+    "timestamp": 1710000000000,
+    "data": {
+      "event": "message-start",
+      "role": "ai",
+      "id": "msg_123"
+    }
+  }
+}
+```
+
+The optional `eventId` maps to the SSE `id:` field and is used for transport
+reconnection. The optional `seq` is a monotonic sequence number used for
+ordering and replay.
+
+## Threads, Runs, and Input
+
+The protocol is thread-centric. A thread is the durable identity for state,
+checkpoints, run history, and stream routing. A server may create a thread
+lazily when it receives the first `run.input` command for a thread that does not
+exist yet.
+
+`run.input` is the main entry point for execution input:
+
+- If no run is active, it starts a new run.
+- If the run is interrupted, it resumes the run with the provided value.
+- If a run is active, it injects input into the running graph.
+
+The command carries the target `assistantId`, arbitrary graph input, optional
+runtime config, and optional metadata.
+
+Human-in-the-loop control uses the input module:
+
+- `input.requested` events ask the client for a response to an interrupt.
+- `input.respond` sends a response correlated by `interruptId`.
+- `input.inject` sends unsolicited user or system input into a namespace.
+
+## Namespaces
+
+A namespace is a path of strings identifying a location in the agent tree:
+
+- `[]` identifies the root agent or graph.
+- `["researcher"]` identifies a direct child.
+- `["supervisor", "worker_a"]` identifies a nested child.
+
+Subscriptions can filter by namespace prefix and optional depth. This allows a
+client to observe the whole tree, a single subgraph, or a bounded region under a
+subgraph without receiving unrelated events.
+
+## Channels
+
+Channels are the primary subscription unit. A client requests one or more
+channels and receives only matching events.
+
+### `messages`
+
+The `messages` channel streams transcript messages and content blocks. It uses
+explicit event boundaries:
+
+1. `message-start`
+2. `content-block-start`
+3. zero or more `content-block-delta` events
+4. `content-block-finish`
+5. repeat content block events for additional blocks
+6. `message-finish`
+
+Content blocks do not interleave within a single message. Block `N` finishes
+before block `N + 1` starts. This matches common LLM provider streaming behavior
+and keeps client assembly deterministic.
+
+Delta events carry the same content block union as finalized content. The
+block's `type` field is the discriminant. For example:
+
+```json
+{
+  "event": "content-block-delta",
+  "index": 0,
+  "content": {
+    "type": "text",
+    "text": "Hello "
+  }
+}
+```
+
+Tool call arguments stream as chunk content and finalize as parsed tool calls:
+
+```json
+{
+  "event": "content-block-delta",
+  "index": 1,
+  "content": {
+    "type": "tool_call_chunk",
+    "id": "call_123",
+    "name": "search",
+    "args": "{\"query\":"
+  }
+}
+```
+
+```json
+{
+  "event": "content-block-finish",
+  "index": 1,
+  "content": {
+    "type": "tool_call",
+    "id": "call_123",
+    "name": "search",
+    "args": {
+      "query": "weather"
+    }
+  }
+}
+```
+
+`message-finish` may include token usage for AI-authored messages.
+Unrecoverable model-call failures are emitted as message `error` events.
+
+### `tools`
+
+The `tools` channel exposes tool execution lifecycle observability:
+
+1. `tool-started`
+2. zero or more `tool-output-delta` events for streaming tools
+3. `tool-finished` or `tool-error`
+
+Tool events are correlated by `toolCallId`. Clients can connect a tool execution
+back to a tool call content block by matching the tool call content block `id`
+with `toolCallId`.
+
+### `lifecycle`
+
+The `lifecycle` channel tracks root run and subgraph status:
+
+- `started`
+- `running`
+- `completed`
+- `failed`
+- `interrupted`
+
+Lifecycle events include a `namespace`, optional `graphName`, optional `error`,
+optional `checkpoint`, and optional `cause`.
+
+The `cause` field explains why a child namespace started. Current cause variants
+include:
+
+- `toolCall`: a parent tool call spawned the child graph.
+- `send`: a parent graph used a fan-out send primitive.
+- `edge`: a graph edge transitioned into a child graph.
+
+Consumers should tolerate unknown cause types so new cause variants can be added
+without breaking existing clients.
+
+### `input`
+
+The `input` channel carries human-in-the-loop requests. An `input.requested`
+event contains an `interruptId` and application-defined `payload`. Clients
+answer with `input.respond`, passing the same namespace and interrupt ID.
+
+### `values`
+
+The `values` channel carries full graph state snapshots. When a subscription is
+created, the first replayed `values` event is the current full state, giving the
+client a stable baseline before applying deltas from other channels.
+
+### `updates`
+
+The `updates` channel carries per-node or per-step state deltas:
+
+```json
+{
+  "method": "updates",
+  "params": {
+    "namespace": [],
+    "timestamp": 1710000000000,
+    "data": {
+      "node": "agent",
+      "values": {
+        "messages": []
+      }
+    }
+  }
+}
+```
+
+Clients that need complete state should subscribe to `values` for an initial
+snapshot and use `updates` for incremental changes.
+
+### `checkpoints`
+
+The `checkpoints` channel emits lightweight checkpoint envelopes. Each envelope
+includes:
+
+- `id`: the fork target for `state.fork`.
+- `parentId`: optional parent checkpoint ID for tree reconstruction.
+- `step`: superstep number.
+- `source`: one of `input`, `loop`, `update`, or `fork`.
+
+This lets clients build branching and time-travel interfaces without streaming
+full checkpoint state. Full state can be fetched lazily with `state.get` or in
+bulk with `state.listCheckpoints`.
+
+A checkpoint event is emitted on the same superstep as the corresponding
+`values` event. Clients subscribed to both can correlate them by namespace and
+step, or by adjacent event sequence numbers.
+
+### `tasks`
+
+The `tasks` channel carries Pregel task creation and result events. Its payload
+shape is intentionally open because it follows the runtime task representation.
+
+### `custom` and `custom:*`
+
+The `custom` channel carries user-defined payloads emitted from graph code. The
+base `custom` channel uses a `name` and `payload` envelope. Namespaced custom
+channels such as `custom:progress` allow applications to define more specific
+event lanes while keeping the protocol extensible.
+
+## State and Checkpoints
+
+The state module provides command-level access to graph state:
+
+- `state.get` reads current state values for a namespace, optionally restricted
+  to selected keys.
+- `state.listCheckpoints` lists checkpoint summaries, optionally scoped to a
+  namespace.
+- `state.fork` starts a run from a checkpoint and returns the new `runId` and
+  `threadId`.
+
+State access complements streaming. Streams provide live observation; state
+commands provide explicit reads and time-travel operations.
+
+## Replay and Reconnection
+
+Servers may keep a ring buffer of recent events per thread. Clients use sequence
+numbers to recover missed events:
+
+- SSE clients pass `since` in `EventStreamRequest`.
+- WebSocket clients call `subscription.reconnect` with `lastEventId` and the
+  subscriptions they want restored.
+
+The server replays matching buffered events after the requested point and then
+switches to live delivery. If the requested event is no longer buffered, servers
+should report that the client missed events so the client can resync through
+state commands.
+
+## Extensibility
+
+Most records include an `Extensible` tail, allowing additional text-keyed fields
+for forward compatibility. Consumers should ignore unknown fields and default
+unknown tagged variants to a safe fallback instead of failing closed.
+
+Content blocks are especially extensible. New block types can be added to
+LangChain content block definitions and flow through the same message lifecycle
+without changing the transport or channel model.
+
+## Generated Bindings
+
+The `js` and `py` directories contain generated type bindings for the CDDL
+schema. They are intended for typing protocol payloads, not as runtime clients.
+The packages do not include transport implementations, connection management, or
+helper APIs.
+
+When the CDDL schema changes, regenerate the language bindings from
+`streaming/protocol.cddl` and keep the generated files in sync.

--- a/streaming/js/LICENSE
+++ b/streaming/js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LangChain, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/streaming/js/README.md
+++ b/streaming/js/README.md
@@ -1,0 +1,67 @@
+# `@langchain/protocol`
+
+TypeScript bindings for the LangChain agent streaming protocol.
+
+This package publishes the generated TypeScript schema bindings from
+`protocol.cddl` so TypeScript applications can type protocol commands, events,
+results, and content blocks consistently.
+
+## What this package includes
+
+- Generated TypeScript protocol bindings in `protocol.ts`
+- Types for top-level messages such as `Command`, `Message`, and protocol events
+- Types for protocol modules including session, subscription, resource,
+  sandbox, input, state, and usage
+
+## What this package does not include
+
+This package does not currently ship a runtime client, transport, or helper APIs
+such as `createSession()`. It is intended for typing protocol payloads and
+generated bindings only.
+
+## Installation
+
+```bash
+npm install @langchain/protocol
+```
+
+## Usage
+
+Use type-only imports when consuming the protocol schema:
+
+```ts
+import type {
+  Command,
+  Message,
+  SessionOpenParams,
+  SubscribeParams,
+  MessagesEvent,
+} from "@langchain/protocol";
+```
+
+You can then use the exported types to model protocol payloads in your own
+transport or client implementation:
+
+```ts
+import type { Command, SessionOpenParams } from "@langchain/protocol";
+
+const params: SessionOpenParams = {
+  protocolVersion: "0.3.0",
+};
+
+const openCommand: Command = {
+  id: 1,
+  method: "session.open",
+  params,
+};
+```
+
+## Versioning
+
+The package version is aligned with the draft streaming protocol schema version.
+The current generated bindings target protocol `0.5.0`.
+
+## Source of truth
+
+The canonical protocol definition lives at `../protocol.cddl`. The TypeScript
+bindings in this package are generated from that schema.

--- a/streaming/js/README.md
+++ b/streaming/js/README.md
@@ -10,14 +10,13 @@ results, and content blocks consistently.
 
 - Generated TypeScript protocol bindings in `protocol.ts`
 - Types for top-level messages such as `Command`, `Message`, and protocol events
-- Types for protocol modules including session, subscription, resource,
-  sandbox, input, state, and usage
+- Types for protocol modules including run, subscription, agent, input, state,
+  and usage
 
 ## What this package does not include
 
-This package does not currently ship a runtime client, transport, or helper APIs
-such as `createSession()`. It is intended for typing protocol payloads and
-generated bindings only.
+This package does not currently ship a runtime client, transport, or helper APIs.
+It is intended for typing protocol payloads and generated bindings only.
 
 ## Installation
 
@@ -33,7 +32,6 @@ Use type-only imports when consuming the protocol schema:
 import type {
   Command,
   Message,
-  SessionOpenParams,
   SubscribeParams,
   MessagesEvent,
 } from "@langchain/protocol";
@@ -43,25 +41,20 @@ You can then use the exported types to model protocol payloads in your own
 transport or client implementation:
 
 ```ts
-import type { Command, SessionOpenParams } from "@langchain/protocol";
+import type { Command, SubscribeParams } from "@langchain/protocol";
 
-const params: SessionOpenParams = {
-  protocolVersion: "0.3.0",
+const params: SubscribeParams = {
+  channels: ["messages", "lifecycle"],
 };
 
-const openCommand: Command = {
+const subscribeCommand: Command = {
   id: 1,
-  method: "session.open",
+  method: "subscription.subscribe",
   params,
 };
 ```
 
-## Versioning
-
-The package version is aligned with the draft streaming protocol schema version.
-The current generated bindings target protocol `0.5.0`.
-
 ## Source of truth
 
-The canonical protocol definition lives at `../protocol.cddl`. The TypeScript
+The canonical protocol definition lives at [`protocol.cddl`]([https://](https://github.com/langchain-ai/agent-protocol/blob/main/streaming/protocol.cddl)). The TypeScript
 bindings in this package are generated from that schema.

--- a/streaming/js/package.json
+++ b/streaming/js/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@langchain/protocol",
+  "version": "0.0.13",
+  "description": "TypeScript bindings for the LangChain agent streaming protocol",
+  "license": "MIT",
+  "keywords": [
+    "langchain",
+    "langgraph",
+    "protocol",
+    "streaming",
+    "agents",
+    "typescript"
+  ],
+  "types": "./protocol.ts",
+  "exports": {
+    ".": {
+      "types": "./protocol.ts",
+      "default": "./protocol.ts"
+    }
+  },
+  "files": [
+    "protocol.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -16,7 +16,7 @@
 // - Namespace-based filtering provides server-side routing
 // - Threads are the primary routing key across all transports
 // Status: DRAFT
-// Version: 0.5.0
+// Version: 0.0.13
 // ==========================================================================
 // ==========================================================================
 // 1. Shared Primitives

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -289,10 +289,10 @@ export type ErrorCode = "invalid_argument" | "unknown_command" | "unknown_error"
 // not already exist.
 // Transport endpoints:
 // **SSE/HTTP:**
-// POST /v2/threads/:thread_id/events   — filtered SSE event stream
-// POST /v2/threads/:thread_id/commands  — JSON command request/response
+// POST /threads/:thread_id/stream   — filtered SSE event stream
+// POST /threads/:thread_id/commands  — JSON command request/response
 // **WebSocket:**
-// ws://.../v2/threads/:thread_id        — full-duplex connection
+// ws://.../threads/:thread_id/stream — full-duplex connection
 // Subscription model varies by transport:
 // **SSE/HTTP:** Subscriptions are connection-scoped. Each
 // `POST .../events` request carries its own filter (channels, namespaces,
@@ -372,7 +372,7 @@ export interface RunResult {
 // 6. Subscription & Event Streaming
 // The protocol supports two subscription models depending on transport:
 // **SSE/HTTP transport (connection-scoped subscriptions):**
-// Clients open one or more `POST /v2/threads/:thread_id/events` requests,
+// Clients open one or more `POST /threads/:thread_id/stream` requests,
 // each carrying an `EventStreamRequest` body with the desired channel
 // and namespace filters. The server responds with an SSE stream
 // filtered to match. Each connection IS the subscription — closing
@@ -396,7 +396,7 @@ export interface RunResult {
 // purpose.
 // ==========================================================================
 // --- Event stream request (SSE/HTTP transport only) ---
-// Sent as the JSON body of `POST /v2/threads/:thread_id/events`.
+// Sent as the JSON body of `POST /threads/:thread_id/stream`.
 // The server responds with `Content-Type: text/event-stream`.
 export type Channel = "values" | "updates" | "messages" | "tools" | "lifecycle" | "input" | "checkpoints" | "tasks" | "custom" | `custom:${string}`;
 

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -1,0 +1,1078 @@
+// ==========================================================================
+// LangGraph Agent Streaming Protocol — Unified CDDL Schema
+// Concise Data Definition Language (RFC 8610) specification for the
+// LangGraph Agent Streaming Protocol. This file is the single source
+// of truth from which TypeScript, Python, and Java types are generated.
+// This specification unifies two protocol perspectives:
+// 1. In-process protocol — content-block-centric, layered event model
+// with typed lifecycle semantics (start/delta/finish) at each
+// abstraction level (chat model, tool, graph, agent).
+// 2. Streaming protocol — thread-centric design with connection-scoped
+// event filtering, hierarchical namespace scoping, and multi-transport
+// support (WebSocket, SSE, in-process).
+// The result is a single protocol where:
+// - Content blocks are the universal delta carrier for LLM streaming
+// - Events have full lifecycle semantics (no inferred boundaries)
+// - Namespace-based filtering provides server-side routing
+// - Threads are the primary routing key across all transports
+// Status: DRAFT
+// Version: 0.5.0
+// ==========================================================================
+// ==========================================================================
+// 1. Shared Primitives
+// ==========================================================================
+// JavaScript safe integer range
+export type JsInt = number;
+
+// Hierarchical path identifying a position in the agent tree.
+// [] = root agent, ["agent_1"] = direct child, ["agent_1", "researcher"] = nested.
+export type JsUint = number;
+
+// Allows additional text-keyed fields for forward compatibility.
+export type Namespace = string[];
+
+// Milliseconds since Unix epoch.
+export type Extensible = Record<string, any>;
+
+// Flat scalar value used by concise metadata bags.
+export type Timestamp = number;
+
+// Author role for a transcript message on the messages channel.
+export type MetadataScalar = null | boolean | number | number | string;
+
+// Concise provider/model metadata for a streamed message.
+// This is not a general-purpose tracing/debug payload.
+// Implementations SHOULD NOT include large nested objects, arrays,
+// version maps, or runtime internals here.
+export type MessageRole = "ai" | "human" | "system";
+
+// ==========================================================================
+// 2. Content Block Types
+// LangChain content blocks are the universal carrier for streaming
+// deltas. The block's `type` field is the discriminant. New content
+// block types automatically work with the streaming protocol without
+// protocol changes.
+// "Chunk" variants (ToolCallChunk, ServerToolCallChunk) carry
+// partial/incremental data during streaming. "Standard" variants carry
+// finalized data. ContentBlockFinish events upgrade chunks to their
+// standard counterparts (e.g. ToolCallChunk -> ToolCall).
+// ==========================================================================
+export interface MessageMetadata {
+  provider?: string;
+  model?: string;
+  model_type?: string;
+  run_id?: string;
+  thread_id?: string;
+  system_fingerprint?: string;
+  service_tier?: string;
+  [key: string]: MetadataScalar | undefined;
+}
+
+// Union of all multimodal data content block types.
+export type ContentBlock = TextContentBlock | InvalidToolCall | ReasoningContentBlock | NonStandardContentBlock | DataContentBlock | ToolContentBlock;
+
+// Union of all tool-related content block types (chunk and finalized).
+export type DataContentBlock = ImageContentBlock | VideoContentBlock | AudioContentBlock | FileContentBlock;
+
+// Finalized content blocks (non-chunk types). Used in content-block-finish.
+export type ToolContentBlock = ToolCall | ToolCallChunk | ServerToolCall | ServerToolCallChunk | ServerToolResult;
+
+// Index of a block in an aggregate response. Used during streaming.
+export type FinalizedContentBlock = TextContentBlock | ReasoningContentBlock | ToolCall | InvalidToolCall | ServerToolCall | ServerToolResult | DataContentBlock | NonStandardContentBlock;
+
+export type BlockIndex = JsInt | string;
+
+export type TextContentBlock = Extensible & {
+  type: string;
+  text: string;
+  id?: string;
+  index?: BlockIndex;
+  annotations?: Annotation[];
+};
+
+export type Annotation = Citation | NonStandardAnnotation;
+
+export type Citation = Extensible & {
+  type: "citation";
+  id?: string;
+  url?: string;
+  title?: string;
+  start_index?: number;
+  end_index?: number;
+  cited_text?: string;
+};
+
+export type NonStandardAnnotation = Extensible & {
+  type: "non_standard_annotation";
+  id?: string;
+  value: Record<string, any>;
+};
+
+export type ReasoningContentBlock = Extensible & {
+  type: "reasoning";
+  reasoning?: string;
+  id?: string;
+  index?: BlockIndex;
+};
+
+export type ToolCall = Extensible & {
+  type: "tool_call";
+  id: string | null;
+  name: string;
+  args: Record<string, any>;
+  index?: BlockIndex;
+};
+
+export type ToolCallChunk = Extensible & {
+  type: "tool_call_chunk";
+  id: string | null;
+  name: string | null;
+  /**
+   * Partial JSON string
+   */
+  args: string | null;
+  index?: BlockIndex;
+};
+
+export type InvalidToolCall = Extensible & {
+  type: "invalid_tool_call";
+  id: string | null;
+  name: string | null;
+  args: string | null;
+  error: string | null;
+  index?: BlockIndex;
+};
+
+export type ServerToolCall = Extensible & {
+  type: "server_tool_call";
+  id: string;
+  name: string;
+  args: Record<string, any>;
+  index?: BlockIndex;
+};
+
+export type ServerToolCallChunk = Extensible & {
+  type: "server_tool_call_chunk";
+  id?: string;
+  name?: string;
+  args?: string;
+  index?: BlockIndex;
+};
+
+export type ServerToolResult = Extensible & {
+  type: "server_tool_result";
+  tool_call_id: string;
+  status: "success" | "error";
+  id?: string;
+  output?: any;
+  index?: BlockIndex;
+};
+
+export type ImageContentBlock = Extensible & {
+  type: "image";
+  id?: string;
+  file_id?: string;
+  url?: string;
+  /**
+   * Base64-encoded image data
+   */
+  base64?: string;
+  mime_type?: string;
+  index?: BlockIndex;
+};
+
+export type AudioContentBlock = Extensible & {
+  type: "audio";
+  id?: string;
+  file_id?: string;
+  url?: string;
+  /**
+   * Base64-encoded audio data
+   */
+  base64?: string;
+  mime_type?: string;
+  index?: BlockIndex;
+};
+
+export type VideoContentBlock = Extensible & {
+  type: "video";
+  id?: string;
+  file_id?: string;
+  url?: string;
+  /**
+   * Base64-encoded video data
+   */
+  base64?: string;
+  mime_type?: string;
+  index?: BlockIndex;
+};
+
+// Provider-specific escape hatch for content blocks not modeled above.
+export type FileContentBlock = Extensible & {
+  type: "file";
+  id?: string;
+  file_id?: string;
+  url?: string;
+  /**
+   * Base64-encoded file data
+   */
+  base64?: string;
+  mime_type?: string;
+  index?: BlockIndex;
+};
+
+// ==========================================================================
+// 3. Top-Level Message Framing
+// Three message types flow over the connection:
+// Command         — client -> server
+// CommandResponse — server -> client (success)
+// ErrorResponse   — server -> client (failure)
+// Event           — server -> client (unsolicited push)
+// ==========================================================================
+// --- Client -> Server ---
+export type NonStandardContentBlock = Extensible & {
+  type: "non_standard";
+  value: Record<string, any>;
+  id?: string;
+  index?: BlockIndex;
+};
+
+export type Command = CommandData & Extensible & {
+  id: JsUint;
+};
+
+// --- Server -> Client ---
+export type CommandData = RunCommand | SubscriptionCommand | AgentCommand | InputCommand | StateCommand;
+
+export type Message = CommandResponse | ErrorResponse | Event;
+
+export type CommandResponse = Extensible & {
+  type: "success";
+  id: JsUint;
+  result: ResultData;
+  meta?: ResponseMeta;
+};
+
+export type ErrorResponse = Extensible & {
+  type: "error";
+  id: JsUint | null;
+  error: ErrorCode;
+  message: string;
+  stacktrace?: string;
+  meta?: ResponseMeta;
+};
+
+// --- Result / Error enums ---
+export type Event = EventData & Extensible & {
+  type: "event";
+  /**
+   * Unique ID for reconnection (maps to SSE id:)
+   */
+  event_id?: string;
+  /**
+   * Monotonic sequence number for ordering
+   */
+  seq?: JsUint;
+};
+
+export type ResultData = RunResult | SubscriptionResult | AgentResult | InputResult | StateResult | EmptyResult;
+export type EmptyResult = Extensible;
+export type ErrorCode = "invalid_argument" | "unknown_command" | "unknown_error" | "no_such_run" | "no_such_subscription" | "no_such_namespace" | "no_such_interrupt" | "no_such_checkpoint" | "permission_denied" | "not_supported";
+
+// ==========================================================================
+// 4. Thread-Centric Model
+// The protocol is thread-centric: threads are the primary routing key
+// for commands, events, and subscriptions. There is no session handshake
+// or server-side session state.
+// Thread IDs may be client-generated (UUID) or server-assigned. The
+// server creates the thread lazily on the first `run.input` if it does
+// not already exist.
+// Transport endpoints:
+// **SSE/HTTP:**
+// POST /v2/threads/:thread_id/events   — filtered SSE event stream
+// POST /v2/threads/:thread_id/commands  — JSON command request/response
+// **WebSocket:**
+// ws://.../v2/threads/:thread_id        — full-duplex connection
+// Subscription model varies by transport:
+// **SSE/HTTP:** Subscriptions are connection-scoped. Each
+// `POST .../events` request carries its own filter (channels, namespaces,
+// depth) and the server streams matching events for the lifetime of that
+// connection. Closing the connection unsubscribes. No subscription state
+// is persisted on the server. Event streams can be opened before or after
+// `run.input`; streams opened before a run exists stay idle until events
+// are produced.
+// **WebSocket:** Subscriptions are managed via in-band
+// `subscription.subscribe` and `subscription.unsubscribe` commands on
+// the single bidirectional connection. Subscriptions persist across run
+// boundaries and are removed by explicit `subscription.unsubscribe` or
+// when the WebSocket connection is closed.
+// Multiple connections may observe the same thread concurrently, each
+// with independent event filters. The thread is the durable identity
+// (checkpoint, state, run history); each connection is an ephemeral
+// transport scope for what a particular consumer sees.
+// Cleanup is implicit: when the run completes and all connections close,
+// the server drops ephemeral in-memory state (event buffer, run session).
+// The thread itself persists in the checkpoint store.
+// ==========================================================================
+// ==========================================================================
+// 4a. Run Module
+// `run.input` is the single entry point for all input to the graph.
+// The thread manages a state machine:
+// - No active run  → starts a new run with the provided input
+// - Run interrupted → resumes with the input as the resume value
+// - Run active      → injects input into the running graph
+// The `assistantId` field identifies which deployed graph or agent to
+// run on this thread. It replaces session-level target binding.
+// ==========================================================================
+export type ResponseMeta = Extensible & {
+  applied_through_seq?: JsUint;
+};
+
+export type RunCommand = RunInput;
+
+export interface RunInput {
+  method: "run.input";
+  params: RunInputParams;
+}
+
+export interface RunInputParams {
+  /**
+   * Deployed graph/agent to run
+   */
+  assistant_id: string;
+  /**
+   * Graph input, resume value, or injected message
+   */
+  input: any;
+  /**
+   * Per-run config overrides
+   */
+  config?: Record<string, any>;
+  /**
+   * Per-run metadata
+   */
+  metadata?: Record<string, any>;
+}
+
+// ==========================================================================
+// 5. Channels
+// Each channel corresponds to a subscribable event stream. Clients
+// include channel names in event stream filters or subscription commands
+// to select which event types to receive.
+// ==========================================================================
+export interface RunResult {
+  /**
+   * ID of the started or resumed run
+   */
+  run_id?: string;
+}
+
+// Namespaced custom channels (e.g. "custom:my-events")
+// ==========================================================================
+// 6. Subscription & Event Streaming
+// The protocol supports two subscription models depending on transport:
+// **SSE/HTTP transport (connection-scoped subscriptions):**
+// Clients open one or more `POST /v2/threads/:thread_id/events` requests,
+// each carrying an `EventStreamRequest` body with the desired channel
+// and namespace filters. The server responds with an SSE stream
+// filtered to match. Each connection IS the subscription — closing
+// the connection unsubscribes. No subscription state is persisted on
+// the server beyond the lifetime of the TCP connection.
+// Multiple concurrent event streams are supported. Each stream
+// independently filters the same underlying event source. Clients
+// may bundle multiple channels into one connection or open dedicated
+// connections per channel.
+// **WebSocket transport (in-band command subscriptions):**
+// WebSocket connections use `subscription.subscribe` and
+// `subscription.unsubscribe` as in-band commands on the single
+// bidirectional connection. Subscriptions persist across run
+// boundaries and are removed by explicit `subscription.unsubscribe`
+// or when the connection is closed.
+// **Replay / reconnection:**
+// For SSE/HTTP, the `EventStreamRequest` includes an optional `since`
+// field (sequence number). The server replays matching events from its
+// ring buffer starting after that sequence, then switches to live
+// delivery. For WebSocket, `subscription.reconnect` serves the same
+// purpose.
+// ==========================================================================
+// --- Event stream request (SSE/HTTP transport only) ---
+// Sent as the JSON body of `POST /v2/threads/:thread_id/events`.
+// The server responds with `Content-Type: text/event-stream`.
+export type Channel = "values" | "updates" | "messages" | "tools" | "lifecycle" | "input" | "checkpoints" | "tasks" | "custom" | `custom:${string}`;
+
+// --- WebSocket-only subscription commands ---
+export type EventStreamRequest = Extensible & {
+  channels: Channel[];
+  /**
+   * Prefix-match these namespace paths
+   */
+  namespaces?: Namespace[];
+  /**
+   * Max depth below namespace prefix
+   */
+  depth?: number;
+  /**
+   * Replay events after this seq number
+   */
+  since?: JsUint;
+};
+
+export type SubscriptionCommand = SubscriptionSubscribe | SubscriptionUnsubscribe | SubscriptionReconnect;
+
+export interface SubscriptionSubscribe {
+  method: "subscription.subscribe";
+  params: SubscribeParams;
+}
+
+export type SubscribeParams = Extensible & {
+  channels: Channel[];
+  /**
+   * Prefix-match these namespace paths
+   */
+  namespaces?: Namespace[];
+  /**
+   * Max depth below namespace prefix
+   */
+  depth?: number;
+};
+
+export type SubscribeResult = Extensible & {
+  subscription_id: string;
+  /**
+   * Events replayed from buffer
+   */
+  replayed_events?: number;
+};
+
+export interface SubscriptionUnsubscribe {
+  method: "subscription.unsubscribe";
+  params: UnsubscribeParams;
+}
+
+export type UnsubscribeParams = Extensible & {
+  subscription_id: string;
+};
+
+export interface SubscriptionReconnect {
+  method: "subscription.reconnect";
+  params: ReconnectParams;
+}
+
+export type ReconnectParams = Extensible & {
+  run_id: string;
+  /**
+   * Last event the client processed
+   */
+  last_event_id?: string;
+  /**
+   * Subscription IDs to restore
+   */
+  subscriptions?: string[];
+};
+
+export type ReconnectResult = Extensible & {
+  restored: boolean;
+  missed_events?: number;
+  current_namespaces?: AgentStatusEntry[];
+};
+
+export type AgentStatusEntry = Extensible & {
+  namespace: Namespace;
+  status: AgentStatus;
+};
+
+// ==========================================================================
+// 7. Agent / Lifecycle Module
+// Hierarchy discovery and lifecycle tracking. The lifecycle channel
+// tracks the status of every namespace in the agent tree and provides
+// parent→child correlation for subgraph discovery via the `cause`
+// field on `started` events.
+// See proposal §17 (Channel Architecture) for the design rationale.
+// ==========================================================================
+export type SubscriptionResult = SubscribeResult | ReconnectResult | EmptyResult;
+
+// --- agent.getTree ---
+export type AgentCommand = AgentGetTree;
+
+export interface AgentGetTree {
+  method: "agent.getTree";
+  params: AgentGetTreeParams;
+}
+
+export interface AgentGetTreeParams {
+  run_id?: string;
+}
+
+export interface AgentTreeNode {
+  namespace: Namespace;
+  status: AgentStatus;
+  graph_name: string;
+  children?: AgentTreeNode[];
+  metadata?: Record<string, any>;
+}
+
+export interface AgentResult {
+  tree: AgentTreeNode;
+}
+
+// --- Event registry ---
+// All server -> client events are registered here as a group choice.
+export type AgentStatus = "started" | "running" | "completed" | "failed" | "interrupted";
+
+// --- Lifecycle events (server -> client, channel: "lifecycle") ---
+// Lifecycle events track the status of the root run and all subgraphs.
+// The optional `cause` field on `started` events correlates a child
+// namespace back to whatever on the parent namespace triggered it,
+// enabling over-the-wire clients to reconstruct the subgraph tree
+// without product-specific knowledge.
+export type EventData = LifecycleEvent | MessagesEvent | ToolsEvent | InputEvent | ValuesEvent | UpdatesEvent | CheckpointsEvent | CustomEvent | TasksEvent;
+
+// Causation edge for a subgraph's `started` lifecycle event.
+// Identifies what on the parent namespace caused this subgraph to
+// start. Populated by product-specific stream transformers (e.g.
+// deepagents' SubagentTransformer) before events reach the wire.
+// langgraph core and langgraph-api are product-agnostic and do not
+// populate this field. Optional — absent for the root graph and
+// for subgraphs whose spawning mechanism isn't yet modelled.
+// Extensible via new variants; consumers MUST default-case unknown
+// `type` values to "unknown cause" rather than erroring, so future
+// additions don't break pinned clients.
+export interface LifecycleEvent {
+  method: "lifecycle";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    data: LifecycleData;
+  };
+}
+
+// A tool call on the parent namespace spawned this subgraph.
+// How it's produced in code:
+// A tool node's handler body invokes a compiled subgraph — e.g.
+// `await subagent.ainvoke(...)` or `subagent.astream(...)` from
+// inside a `@tool`-decorated function. Deepagents' `task` tool
+// is the canonical example: it calls `subagent.ainvoke(input)`
+// to execute a nested agent, and each call becomes one subgraph
+// run correlated back to the originating `tool_call_id`.
+// Populated by: product-specific stream transformer (e.g.
+// deepagents' SubagentTransformer / createSubagentTransformer).
+export type LifecycleCause = LifecycleCauseToolCall | LifecycleCauseSend | LifecycleCauseEdge;
+
+// A `Send` dispatched from a parent node spawned this subgraph.
+// How it's produced in code:
+// A parent node returns/yields one or more `Send(node, state)`
+// objects (langgraph's fan-out primitive). Each `Send` creates a
+// parallel pregel task; when the target node embeds a compiled
+// subgraph, each `Send` instance spawns its own subgraph run.
+// Typical in supervisor/worker patterns where the supervisor
+// yields `Send("worker", work_item)` once per item.
+// Populated by: (no transformer in current releases; declared for
+// future supervisor-pattern transformers to emit).
+export interface LifecycleCauseToolCall {
+  /**
+   * The `tool_call_id` from the originating `tool-started` event
+   */
+  type: "toolCall";
+  /**
+   * on the parent namespace. Matches the `id` field of the
+   * originating `tool_call` content block in the parent AI message.
+   */
+  tool_call_id: string;
+}
+
+// A graph edge transitioned into this subgraph's entry node.
+// How it's produced in code:
+// A static edge (`graph.add_edge("a", "b")`) or a conditional
+// edge (`graph.add_conditional_edges("a", router_fn)`) routes
+// control into a node that embeds a compiled subgraph. Unlike
+// `Send`, edge transitions are single-successor and do not
+// fan out — one edge traversal produces exactly one subgraph run.
+// Populated by: (no transformer in current releases; declared for
+// future embedded-subgraph transformers to emit).
+export interface LifecycleCauseSend {
+  /**
+   * Name of the parent node that issued the `Send`. Multiple Sends
+   */
+  type: "send";
+  /**
+   * from the same node in the same superstep share this value;
+   * future protocol versions may add a disambiguating `sendIndex`
+   * if per-Send identity is needed on the wire.
+   */
+  from_node: string;
+}
+
+export interface LifecycleCauseEdge {
+  /**
+   * Name of the parent node the edge originated from.
+   */
+  type: "edge";
+  from_node: string;
+}
+
+// ==========================================================================
+// 8. Messages Module
+// Content-block-centric transcript message streaming. AI-authored messages
+// may stream incrementally; human/system messages are typically replayed
+// as complete messages. Events follow a strict lifecycle:
+// message-start
+// -> content-block-start(index=0, contentBlock)
+// -> content-block-delta(index=0, contentBlock) ...
+// -> content-block-finish(index=0, contentBlock)
+// -> content-block-start(index=1, contentBlock)
+// -> content-block-delta(index=1, contentBlock) ...
+// -> content-block-finish(index=1, contentBlock)
+// -> message-finish(reason)
+// Content blocks MUST NOT interleave: block N must finish before block
+// N+1 starts. This constraint applies within a single message
+// (identified by namespace + node) and matches observed behavior of
+// all major LLM providers.
+// Delta events carry LangChain ContentBlock instances directly —
+// the block's `type` field is the discriminant. This means adding
+// a new content block type to LangChain requires zero protocol changes.
+// ==========================================================================
+export interface LifecycleData {
+  event: AgentStatus;
+  graph_name?: string;
+  /**
+   * Causation edge (see LifecycleCause)
+   */
+  cause?: LifecycleCause;
+  error?: string;
+  /**
+   * Checkpoint reference for time-travel
+   */
+  checkpoint?: CheckpointRef;
+}
+
+export interface MessagesEvent {
+  method: "messages";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    /**
+     * Graph node that produced this event
+     */
+    node?: string;
+    data: MessagesData;
+  };
+}
+
+// Emitted once at the start of a streamed or replayed transcript message.
+export type MessagesData = MessageStartData | ContentBlockStartData | ContentBlockDeltaData | ContentBlockFinishData | MessageFinishData | MessageErrorData;
+
+// Emitted when a new content block begins streaming. The contentBlock
+// carries the initial state (e.g. { type: "text", text: "" } or
+// { type: "tool_call_chunk", name: "search", args: "" }).
+export type MessageStartData = Extensible & {
+  event: "message-start";
+  /**
+   * Author role for this message
+   */
+  role: MessageRole;
+  /**
+   * Unique ID for this message
+   */
+  id: string;
+  /**
+   * Concise provider/model metadata for AI messages
+   */
+  metadata?: MessageMetadata;
+};
+
+// Emitted for each incremental update within a content block. The
+// contentBlock carries only the delta for this update:
+// { type: "text", text: "Hello " }           — text delta
+// { type: "reasoning", reasoning: "Let me" } — reasoning delta
+// { type: "tool_call_chunk", args: '{"q":' } — tool call args delta
+export type ContentBlockStartData = Extensible & {
+  event: "content-block-start";
+  /**
+   * Positional index within the message
+   */
+  index: number;
+  content: ContentBlock;
+};
+
+// Emitted when a content block is complete. The contentBlock carries
+// the finalized block. For tool calls, this upgrades ToolCallChunk
+// to ToolCall with parsed args.
+export type ContentBlockDeltaData = Extensible & {
+  event: "content-block-delta";
+  index: number;
+  content: ContentBlock;
+};
+
+// Emitted once when the message is complete.
+export type ContentBlockFinishData = Extensible & {
+  event: "content-block-finish";
+  index: number;
+  content: FinalizedContentBlock;
+};
+
+export type MessageFinishData = Extensible & {
+  event: "message-finish";
+  /**
+   * Token usage for AI-authored messages
+   */
+  usage?: UsageInfo;
+};
+
+// Emitted on unrecoverable errors within a model call.
+export type UsageInfo = Extensible & {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+};
+
+// ==========================================================================
+// 9. Tools Module
+// Tool execution lifecycle observability. Events cover the full
+// lifecycle of a tool invocation:
+// tool-started(toolCallId, toolName)
+// -> tool-output-delta(toolCallId, delta) ...  (optional, streaming tools)
+// -> tool-finished(toolCallId, output)
+// | tool-error(toolCallId, message)
+// ==========================================================================
+export type MessageErrorData = Extensible & {
+  event: "error";
+  message: string;
+  code?: string;
+};
+
+export interface ToolsEvent {
+  method: "tools";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    /**
+     * Graph node executing the tool
+     */
+    node?: string;
+    data: ToolsData;
+  };
+}
+
+// Emitted when tool execution begins.
+export type ToolsData = ToolStartedData | ToolOutputDeltaData | ToolFinishedData | ToolErrorData;
+
+// Emitted for incremental tool output (for tools that stream results).
+export type ToolStartedData = Extensible & {
+  event: "tool-started";
+  tool_call_id: string;
+  tool_name: string;
+  /**
+   * Tool input arguments
+   */
+  input?: any;
+};
+
+// Emitted when tool execution completes successfully.
+export type ToolOutputDeltaData = Extensible & {
+  event: "tool-output-delta";
+  tool_call_id: string;
+  delta: string;
+};
+
+// Emitted when tool execution fails.
+export type ToolFinishedData = Extensible & {
+  event: "tool-finished";
+  tool_call_id: string;
+  output: any;
+};
+
+// ==========================================================================
+// 10. Input Module
+// Human-in-the-loop. Wraps LangGraph's interrupt() / Command({ resume })
+// as in-band protocol messages. Also supports unsolicited user input
+// injection while the agent is running.
+// ==========================================================================
+export type ToolErrorData = Extensible & {
+  event: "tool-error";
+  tool_call_id: string;
+  message: string;
+  code?: string;
+};
+
+// --- input.respond ---
+export type InputCommand = InputRespond | InputInject;
+
+export interface InputRespond {
+  method: "input.respond";
+  params: InputRespondParams;
+}
+
+// --- input.inject ---
+export interface InputRespondParams {
+  namespace: Namespace;
+  interrupt_id: string;
+  response: any;
+}
+
+export interface InputInject {
+  method: "input.inject";
+  params: InputInjectParams;
+}
+
+export interface InputInjectParams {
+  namespace: Namespace;
+  message: InputMessage;
+}
+
+export type InputMessage = Extensible & {
+  role: "user" | "system";
+  content: string;
+  name?: string;
+};
+
+// --- Input events (server -> client, channel: "input") ---
+export type InputResult = EmptyResult;
+
+export interface InputEvent {
+  method: "input.requested";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    data: InputRequestedData;
+  };
+}
+
+// ==========================================================================
+// 11. State Module
+// Graph state and checkpoint access. Enables state inspection and
+// time-travel debugging (fork from checkpoint).
+// Note: Cross-thread store operations (search, put) are accessed via
+// the LangGraph REST API and are not part of the streaming protocol.
+// ==========================================================================
+export type InputRequestedData = Extensible & {
+  /**
+   * Correlates this request with input.respond
+   */
+  interrupt_id: string;
+  /**
+   * Opaque interrupt value from runtime; application-defined shape
+   */
+  payload: any;
+};
+
+// --- state.get ---
+export type StateCommand = StateGet | StateListCheckpoints | StateFork;
+
+export interface StateGet {
+  method: "state.get";
+  params: StateGetParams;
+}
+
+export interface StateGetParams {
+  namespace: Namespace;
+  /**
+   * Specific state keys, or omit for all
+   */
+  keys?: string[];
+}
+
+// --- state.listCheckpoints ---
+export interface StateGetResult {
+  values: Record<string, any>;
+  checkpoint?: CheckpointRef;
+}
+
+export interface StateListCheckpoints {
+  method: "state.listCheckpoints";
+  params: ListCheckpointsParams;
+}
+
+export interface ListCheckpointsParams {
+  namespace?: Namespace;
+  limit?: number;
+  /**
+   * Cursor for pagination
+   */
+  before?: string;
+}
+
+export interface ListCheckpointsResult {
+  checkpoints: CheckpointSummary[];
+}
+
+export interface CheckpointSummary {
+  id: string;
+  /**
+   * ISO 8601
+   */
+  timestamp: string;
+  step: number;
+  /**
+   * Node that produced this checkpoint
+   */
+  node_name?: string;
+  metadata?: Record<string, any>;
+}
+
+// --- state.fork ---
+export interface CheckpointRef {
+  id: string;
+  ns?: string;
+}
+
+export interface StateFork {
+  method: "state.fork";
+  params: StateForkParams;
+}
+
+export interface StateForkParams {
+  checkpoint_id: string;
+  /**
+   * Input for the forked run
+   */
+  input?: any;
+  /**
+   * Config overrides
+   */
+  config?: Record<string, any>;
+}
+
+export interface StateForkResult {
+  run_id: string;
+  thread_id: string;
+}
+
+// ==========================================================================
+// 12. Passthrough Channels
+// These channels carry payloads shaped by the LangGraph runtime and
+// user graph schemas. Their data shapes are intentionally open
+// because they depend on the user's graph state definition.
+// The `values` channel doubles as the "values snapshot" mechanism:
+// when a subscription is created, the first event replayed is the
+// current full state, giving consumers a consistent baseline to
+// apply subsequent deltas against.
+// The `checkpoints` channel carries a lightweight envelope (id,
+// parentId, step, source) emitted once per persisted checkpoint.
+// Clients reconstruct a branching/time-travel history from this
+// metadata alone — the envelope provides the fork target (`id`),
+// tree linkage (`parentId`), and timeline sort/label (`step`,
+// `source`). Full channel state is retrieved lazily via `state.get`
+// or bulk via `state.listCheckpoints`, only for the checkpoints the
+// client actually inspects. Clients that want state snapshots
+// alongside the timeline subscribe to both `values` and
+// `checkpoints`; clients that only need timeline metadata pay only
+// the envelope cost.
+// ==========================================================================
+// --- values (channel: "values") ---
+// Full graph state after each step or initial snapshot.
+export type StateResult = StateGetResult | ListCheckpointsResult | StateForkResult | EmptyResult;
+
+// --- checkpoints (channel: "checkpoints") ---
+// Lightweight checkpoint metadata emitted once per persisted
+// checkpoint. Carries only the envelope needed to build a
+// branching/time-travel UI and to target `state.fork`; full
+// channel state is retrieved on demand via `state.get` /
+// `state.listCheckpoints`.
+// A `checkpoints` event is emitted on the same superstep as the
+// corresponding `values` event; clients that subscribe to both can
+// correlate the pair by (namespace, step) or by adjacent `seq`
+// numbers on the outer event envelope.
+export interface ValuesEvent {
+  method: "values";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    /**
+     * Full graph state after step
+     */
+    data: any;
+  };
+}
+
+// Lightweight checkpoint envelope. Supplies just enough metadata
+// for clients to build a branching/time-travel UI without streaming
+// full channel snapshots.
+export interface CheckpointsEvent {
+  method: "checkpoints";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    data: Checkpoint;
+  };
+}
+
+// Origin tag matching LangGraph's CheckpointMetadata.source.
+export type Checkpoint = Extensible & {
+  /**
+   * Fork target: pass to state.fork / configurable.checkpoint_id
+   */
+  id: string;
+  /**
+   * Parent checkpoint id for tree linkage
+   */
+  parent_id?: string;
+  /**
+   * Superstep number (-1 for first input, 0 for first loop step, ...)
+   */
+  step: number;
+  /**
+   * Origin of the checkpoint
+   */
+  source: CheckpointSource;
+};
+
+// Created as a copy of another checkpoint
+// --- updates (channel: "updates") ---
+// Per-node state deltas.
+export type CheckpointSource = "input" | "loop" | "update" | "fork";
+
+export interface UpdatesEvent {
+  method: "updates";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    data: UpdatesData;
+  };
+}
+
+// --- custom (channel: "custom") ---
+// User-defined payloads emitted via config.writer / getWriter().
+export type UpdatesData = Extensible & {
+  /**
+   * Graph node that produced this update
+   */
+  node?: string;
+  /**
+   * State delta
+   */
+  values: Record<string, any>;
+};
+
+export interface CustomEvent {
+  method: "custom";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    data: CustomData;
+  };
+}
+
+// --- tasks (channel: "tasks") ---
+// Pregel task creation or result events from the graph runtime.
+export type CustomData = Extensible & {
+  /**
+   * Custom event name for dispatch
+   */
+  name?: string;
+  /**
+   * User-defined payload
+   */
+  payload: any;
+};
+
+export interface TasksEvent {
+  method: "tasks";
+  params: {
+    namespace: Namespace;
+    timestamp: Timestamp;
+    /**
+     * Task creation or result
+     */
+    data: any;
+  };
+}

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@langchain/protocol",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Protocol for LangChain",
+    "type": "module",
+    "scripts": {
+        "prepare": "simple-git-hooks",
+        "compile": "pnpm run compile:py && pnpm run compile:ts",
+        "validate:cddl": "cddl validate protocol.cddl",
+        "compile:py": "cddl2py protocol.cddl | python3 scripts/fixup.py > ./py/langchain_protocol/protocol.py",
+        "compile:ts": "cddl2ts protocol.cddl --field-case snake > ./js/protocol.ts",
+        "slides": "cd slides && pnpm run dev"
+    },
+    "dependencies": {
+        "cddl2py": "^0.2.2",
+        "cddl2ts": "^0.9.1"
+    },
+    "packageManager": "pnpm@10.33.0",
+    "devDependencies": {
+        "cddl": "^0.20.1",
+        "lint-staged": "^16.4.0",
+        "simple-git-hooks": "^2.13.1"
+    },
+    "simple-git-hooks": {
+        "pre-commit": "pnpm exec lint-staged"
+    },
+    "lint-staged": {
+        "*": "pnpm run validate:cddl"
+    }
+}

--- a/streaming/pnpm-lock.yaml
+++ b/streaming/pnpm-lock.yaml
@@ -1,0 +1,423 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      cddl2py:
+        specifier: ^0.2.2
+        version: 0.2.2
+      cddl2ts:
+        specifier: ^0.9.1
+        version: 0.9.1
+    devDependencies:
+      cddl:
+        specifier: ^0.20.1
+        version: 0.20.1
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
+
+packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
+  camelcase@9.0.0:
+    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
+    engines: {node: '>=20'}
+
+  cddl2py@0.2.2:
+    resolution: {integrity: sha512-oOM9e89u4ThwXoB67vOyzwTVwZVaoWjlzrczd66ZFcVDStdbuNv8d+pypZaxGsJZqcqn7vr8BMKoTWD588AgiA==}
+    hasBin: true
+
+  cddl2ts@0.9.1:
+    resolution: {integrity: sha512-kF8Axg7HOGS/Os5YojTl51GKXC4DTHt/PaqvV9Naj1QHUABpZV2fVtAvo2dHoZU4ubNbv8aeOOksTOQmIKgfGA==}
+    hasBin: true
+
+  cddl@0.20.1:
+    resolution: {integrity: sha512-aCMHKxLmRDvGcji3tWfXYUW22eK9F+Xrn+a822BvitCeICWyCIrOWZMjNmedRkQLiwdpaZv+wnZ3bfpI9jbKIQ==}
+    hasBin: true
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
+  camelcase@9.0.0: {}
+
+  cddl2py@0.2.2:
+    dependencies:
+      cddl: 0.20.1
+      yargs: 18.0.0
+
+  cddl2ts@0.9.1:
+    dependencies:
+      '@babel/parser': 7.29.2
+      camelcase: 9.0.0
+      cddl: 0.20.1
+      recast: 0.23.11
+      yargs: 18.0.0
+
+  cddl@0.20.1:
+    dependencies:
+      camelcase: 9.0.0
+      yargs: 18.0.0
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  colorette@2.0.20: {}
+
+  commander@14.0.3: {}
+
+  emoji-regex@10.6.0: {}
+
+  environment@1.1.0: {}
+
+  escalade@3.2.0: {}
+
+  esprima@4.0.1: {}
+
+  eventemitter3@5.0.4: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  mimic-function@5.0.1: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  picomatch@4.0.4: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
+
+  signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  source-map@0.6.1: {}
+
+  string-argv@0.3.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  tiny-invariant@1.3.3: {}
+
+  tinyexec@1.1.1: {}
+
+  tslib@2.8.1: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  y18n@5.0.8: {}
+
+  yaml@2.8.3: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0

--- a/streaming/pnpm-workspace.yaml
+++ b/streaming/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - slides

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -22,7 +22,7 @@
 ;   - Threads are the primary routing key across all transports
 ;
 ; Status: DRAFT
-; Version: 0.5.0
+; Version: 0.0.13
 ; ==========================================================================
 
 

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -364,11 +364,11 @@ ResponseMeta = {
 ; Transport endpoints:
 ;
 ; **SSE/HTTP:**
-;   POST /v2/threads/:thread_id/events   — filtered SSE event stream
-;   POST /v2/threads/:thread_id/commands  — JSON command request/response
+;   POST /threads/:thread_id/stream   — filtered SSE event stream
+;   POST /threads/:thread_id/commands  — JSON command request/response
 ;
 ; **WebSocket:**
-;   ws://.../v2/threads/:thread_id        — full-duplex connection
+;   ws://.../threads/:thread_id/stream — full-duplex connection
 ;
 ; Subscription model varies by transport:
 ;
@@ -456,7 +456,7 @@ Channel = "values"                 ; Full graph state snapshots, including initi
 ; The protocol supports two subscription models depending on transport:
 ;
 ; **SSE/HTTP transport (connection-scoped subscriptions):**
-; Clients open one or more `POST /v2/threads/:thread_id/events` requests,
+; Clients open one or more `POST /threads/:thread_id/stream` requests,
 ; each carrying an `EventStreamRequest` body with the desired channel
 ; and namespace filters. The server responds with an SSE stream
 ; filtered to match. Each connection IS the subscription — closing
@@ -485,7 +485,7 @@ Channel = "values"                 ; Full graph state snapshots, including initi
 
 ; --- Event stream request (SSE/HTTP transport only) ---
 ;
-; Sent as the JSON body of `POST /v2/threads/:thread_id/events`.
+; Sent as the JSON body of `POST /threads/:thread_id/stream`.
 ; The server responds with `Content-Type: text/event-stream`.
 
 EventStreamRequest = {

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -1,0 +1,1155 @@
+; ==========================================================================
+; LangGraph Agent Streaming Protocol — Unified CDDL Schema
+;
+; Concise Data Definition Language (RFC 8610) specification for the
+; LangGraph Agent Streaming Protocol. This file is the single source
+; of truth from which TypeScript, Python, and Java types are generated.
+;
+; This specification unifies two protocol perspectives:
+;
+;   1. In-process protocol — content-block-centric, layered event model
+;      with typed lifecycle semantics (start/delta/finish) at each
+;      abstraction level (chat model, tool, graph, agent).
+;
+;   2. Streaming protocol — thread-centric design with connection-scoped
+;      event filtering, hierarchical namespace scoping, and multi-transport
+;      support (WebSocket, SSE, in-process).
+;
+; The result is a single protocol where:
+;   - Content blocks are the universal delta carrier for LLM streaming
+;   - Events have full lifecycle semantics (no inferred boundaries)
+;   - Namespace-based filtering provides server-side routing
+;   - Threads are the primary routing key across all transports
+;
+; Status: DRAFT
+; Version: 0.5.0
+; ==========================================================================
+
+
+; ==========================================================================
+; 1. Shared Primitives
+; ==========================================================================
+
+; JavaScript safe integer range
+js-int = -9007199254740991..9007199254740991
+js-uint = 0..9007199254740991
+
+; Hierarchical path identifying a position in the agent tree.
+; [] = root agent, ["agent_1"] = direct child, ["agent_1", "researcher"] = nested.
+Namespace = [* text]
+
+; Allows additional text-keyed fields for forward compatibility.
+Extensible = (* text => any)
+
+; Milliseconds since Unix epoch.
+Timestamp = uint
+
+; Flat scalar value used by concise metadata bags.
+MetadataScalar = null / bool / int / float / text
+
+; Author role for a transcript message on the messages channel.
+MessageRole = "ai" / "human" / "system"
+
+; Concise provider/model metadata for a streamed message.
+; This is not a general-purpose tracing/debug payload.
+; Implementations SHOULD NOT include large nested objects, arrays,
+; version maps, or runtime internals here.
+MessageMetadata = {
+  ? provider: text,
+  ? model: text,
+  ? modelType: text,
+  ? runId: text,
+  ? threadId: text,
+  ? systemFingerprint: text,
+  ? serviceTier: text,
+  * text => MetadataScalar,
+}
+
+
+; ==========================================================================
+; 2. Content Block Types
+;
+; LangChain content blocks are the universal carrier for streaming
+; deltas. The block's `type` field is the discriminant. New content
+; block types automatically work with the streaming protocol without
+; protocol changes.
+;
+; "Chunk" variants (ToolCallChunk, ServerToolCallChunk) carry
+; partial/incremental data during streaming. "Standard" variants carry
+; finalized data. ContentBlockFinish events upgrade chunks to their
+; standard counterparts (e.g. ToolCallChunk -> ToolCall).
+; ==========================================================================
+
+ContentBlock = TextContentBlock
+             / InvalidToolCall
+             / ReasoningContentBlock
+             / NonStandardContentBlock
+             / DataContentBlock
+             / ToolContentBlock
+
+; Union of all multimodal data content block types.
+DataContentBlock = ImageContentBlock
+                 / VideoContentBlock
+                 / AudioContentBlock
+                 / FileContentBlock
+
+; Union of all tool-related content block types (chunk and finalized).
+ToolContentBlock = ToolCall
+                 / ToolCallChunk
+                 / ServerToolCall
+                 / ServerToolCallChunk
+                 / ServerToolResult
+
+; Finalized content blocks (non-chunk types). Used in content-block-finish.
+FinalizedContentBlock = TextContentBlock
+                      / ReasoningContentBlock
+                      / ToolCall
+                      / InvalidToolCall
+                      / ServerToolCall
+                      / ServerToolResult
+                      / DataContentBlock
+                      / NonStandardContentBlock
+
+; Index of a block in an aggregate response. Used during streaming.
+BlockIndex = js-int / text
+
+TextContentBlock = {
+  type: "text",
+  text: text,
+  ? id: text,
+  ? index: BlockIndex,
+  ? annotations: [* Annotation],
+  Extensible,
+}
+
+Annotation = Citation / NonStandardAnnotation
+
+Citation = {
+  type: "citation",
+  ? id: text,
+  ? url: text,
+  ? title: text,
+  ? startIndex: uint,
+  ? endIndex: uint,
+  ? citedText: text,
+  Extensible,
+}
+
+NonStandardAnnotation = {
+  type: "non_standard_annotation",
+  ? id: text,
+  value: {* text => any},
+  Extensible,
+}
+
+ReasoningContentBlock = {
+  type: "reasoning",
+  ? reasoning: text,
+  ? id: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+ToolCall = {
+  type: "tool_call",
+  id: text / null,
+  name: text,
+  args: {* text => any},
+  ? index: BlockIndex,
+  Extensible,
+}
+
+ToolCallChunk = {
+  type: "tool_call_chunk",
+  id: text / null,
+  name: text / null,
+  args: text / null,                     ; Partial JSON string
+  ? index: BlockIndex,
+  Extensible,
+}
+
+InvalidToolCall = {
+  type: "invalid_tool_call",
+  id: text / null,
+  name: text / null,
+  args: text / null,
+  error: text / null,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+ServerToolCall = {
+  type: "server_tool_call",
+  id: text,
+  name: text,
+  args: {* text => any},
+  ? index: BlockIndex,
+  Extensible,
+}
+
+ServerToolCallChunk = {
+  type: "server_tool_call_chunk",
+  ? id: text,
+  ? name: text,
+  ? args: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+ServerToolResult = {
+  type: "server_tool_result",
+  toolCallId: text,
+  status: "success" / "error",
+  ? id: text,
+  ? output: any,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+ImageContentBlock = {
+  type: "image",
+  ? id: text,
+  ? fileId: text,
+  ? url: text,
+  ? base64: text,                        ; Base64-encoded image data
+  ? mimeType: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+AudioContentBlock = {
+  type: "audio",
+  ? id: text,
+  ? fileId: text,
+  ? url: text,
+  ? base64: text,                        ; Base64-encoded audio data
+  ? mimeType: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+VideoContentBlock = {
+  type: "video",
+  ? id: text,
+  ? fileId: text,
+  ? url: text,
+  ? base64: text,                        ; Base64-encoded video data
+  ? mimeType: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+FileContentBlock = {
+  type: "file",
+  ? id: text,
+  ? fileId: text,
+  ? url: text,
+  ? base64: text,                        ; Base64-encoded file data
+  ? mimeType: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+; Provider-specific escape hatch for content blocks not modeled above.
+NonStandardContentBlock = {
+  type: "non_standard",
+  value: {* text => any},
+  ? id: text,
+  ? index: BlockIndex,
+  Extensible,
+}
+
+
+; ==========================================================================
+; 3. Top-Level Message Framing
+;
+; Three message types flow over the connection:
+;   Command         — client -> server
+;   CommandResponse — server -> client (success)
+;   ErrorResponse   — server -> client (failure)
+;   Event           — server -> client (unsolicited push)
+; ==========================================================================
+
+; --- Client -> Server ---
+
+Command = {
+  id: js-uint,
+  CommandData,
+  Extensible,
+}
+
+CommandData = (
+  RunCommand //
+  SubscriptionCommand //
+  AgentCommand //
+  InputCommand //
+  StateCommand
+)
+
+; --- Server -> Client ---
+
+Message = (
+  CommandResponse /
+  ErrorResponse /
+  Event
+)
+
+CommandResponse = {
+  type: "success",
+  id: js-uint,
+  result: ResultData,
+  ? meta: ResponseMeta,
+  Extensible,
+}
+
+ErrorResponse = {
+  type: "error",
+  id: js-uint / null,
+  error: ErrorCode,
+  message: text,
+  ? stacktrace: text,
+  ? meta: ResponseMeta,
+  Extensible,
+}
+
+Event = {
+  type: "event",
+  ? eventId: text,                       ; Unique ID for reconnection (maps to SSE id:)
+  ? seq: js-uint,                        ; Monotonic sequence number for ordering
+  EventData,
+  Extensible,
+}
+
+; --- Result / Error enums ---
+
+ResultData = (
+  RunResult //
+  SubscriptionResult //
+  AgentResult //
+  InputResult //
+  StateResult //
+  EmptyResult
+)
+
+EmptyResult = { Extensible }
+
+ErrorCode = "invalid_argument"
+          / "unknown_command"
+          / "unknown_error"
+          / "no_such_run"
+          / "no_such_subscription"
+          / "no_such_namespace"
+          / "no_such_interrupt"
+          / "no_such_checkpoint"
+          / "permission_denied"
+          / "not_supported"
+
+ResponseMeta = {
+  ? appliedThroughSeq: js-uint,
+  Extensible,
+}
+
+
+; ==========================================================================
+; 4. Thread-Centric Model
+;
+; The protocol is thread-centric: threads are the primary routing key
+; for commands, events, and subscriptions. There is no session handshake
+; or server-side session state.
+;
+; Thread IDs may be client-generated (UUID) or server-assigned. The
+; server creates the thread lazily on the first `run.input` if it does
+; not already exist.
+;
+; Transport endpoints:
+;
+; **SSE/HTTP:**
+;   POST /v2/threads/:thread_id/events   — filtered SSE event stream
+;   POST /v2/threads/:thread_id/commands  — JSON command request/response
+;
+; **WebSocket:**
+;   ws://.../v2/threads/:thread_id        — full-duplex connection
+;
+; Subscription model varies by transport:
+;
+; **SSE/HTTP:** Subscriptions are connection-scoped. Each
+; `POST .../events` request carries its own filter (channels, namespaces,
+; depth) and the server streams matching events for the lifetime of that
+; connection. Closing the connection unsubscribes. No subscription state
+; is persisted on the server. Event streams can be opened before or after
+; `run.input`; streams opened before a run exists stay idle until events
+; are produced.
+;
+; **WebSocket:** Subscriptions are managed via in-band
+; `subscription.subscribe` and `subscription.unsubscribe` commands on
+; the single bidirectional connection. Subscriptions persist across run
+; boundaries and are removed by explicit `subscription.unsubscribe` or
+; when the WebSocket connection is closed.
+;
+; Multiple connections may observe the same thread concurrently, each
+; with independent event filters. The thread is the durable identity
+; (checkpoint, state, run history); each connection is an ephemeral
+; transport scope for what a particular consumer sees.
+;
+; Cleanup is implicit: when the run completes and all connections close,
+; the server drops ephemeral in-memory state (event buffer, run session).
+; The thread itself persists in the checkpoint store.
+; ==========================================================================
+
+
+; ==========================================================================
+; 4a. Run Module
+;
+; `run.input` is the single entry point for all input to the graph.
+; The thread manages a state machine:
+;
+;   - No active run  → starts a new run with the provided input
+;   - Run interrupted → resumes with the input as the resume value
+;   - Run active      → injects input into the running graph
+;
+; The `assistantId` field identifies which deployed graph or agent to
+; run on this thread. It replaces session-level target binding.
+; ==========================================================================
+
+RunCommand = run.input
+
+run.input = {
+  method: "run.input",
+  params: RunInputParams,
+}
+
+RunInputParams = {
+  assistantId: text,                     ; Deployed graph/agent to run
+  input: any,                            ; Graph input, resume value, or injected message
+  ? config: {* text => any},             ; Per-run config overrides
+  ? metadata: {* text => any},           ; Per-run metadata
+}
+
+RunResult = {
+  ? runId: text,                         ; ID of the started or resumed run
+}
+
+
+; ==========================================================================
+; 5. Channels
+;
+; Each channel corresponds to a subscribable event stream. Clients
+; include channel names in event stream filters or subscription commands
+; to select which event types to receive.
+; ==========================================================================
+
+Channel = "values"                 ; Full graph state snapshots, including initial replay
+        / "updates"                ; Per-step or per-node state deltas
+        / "messages"               ; Transcript message and content-block streaming
+        / "tools"                  ; Tool invocation lifecycle and streamed output
+        / "lifecycle"              ; Run/subgraph status machine with parent→child correlation
+        / "input"                  ; Interrupt requests and human-in-the-loop prompts
+        / "checkpoints"            ; Lightweight checkpoint envelope for branching/time-travel
+        / "tasks"                  ; Pregel task creation and result events
+        / "custom"                 ; User-defined payloads emitted by the graph
+        / tstr .regexp "custom:.+" ; Namespaced custom channels (e.g. "custom:my-events")
+
+
+; ==========================================================================
+; 6. Subscription & Event Streaming
+;
+; The protocol supports two subscription models depending on transport:
+;
+; **SSE/HTTP transport (connection-scoped subscriptions):**
+; Clients open one or more `POST /v2/threads/:thread_id/events` requests,
+; each carrying an `EventStreamRequest` body with the desired channel
+; and namespace filters. The server responds with an SSE stream
+; filtered to match. Each connection IS the subscription — closing
+; the connection unsubscribes. No subscription state is persisted on
+; the server beyond the lifetime of the TCP connection.
+;
+; Multiple concurrent event streams are supported. Each stream
+; independently filters the same underlying event source. Clients
+; may bundle multiple channels into one connection or open dedicated
+; connections per channel.
+;
+; **WebSocket transport (in-band command subscriptions):**
+; WebSocket connections use `subscription.subscribe` and
+; `subscription.unsubscribe` as in-band commands on the single
+; bidirectional connection. Subscriptions persist across run
+; boundaries and are removed by explicit `subscription.unsubscribe`
+; or when the connection is closed.
+;
+; **Replay / reconnection:**
+; For SSE/HTTP, the `EventStreamRequest` includes an optional `since`
+; field (sequence number). The server replays matching events from its
+; ring buffer starting after that sequence, then switches to live
+; delivery. For WebSocket, `subscription.reconnect` serves the same
+; purpose.
+; ==========================================================================
+
+; --- Event stream request (SSE/HTTP transport only) ---
+;
+; Sent as the JSON body of `POST /v2/threads/:thread_id/events`.
+; The server responds with `Content-Type: text/event-stream`.
+
+EventStreamRequest = {
+  channels: [+ Channel],
+  ? namespaces: [* Namespace],           ; Prefix-match these namespace paths
+  ? depth: uint,                         ; Max depth below namespace prefix
+  ? since: js-uint,                      ; Replay events after this seq number
+  Extensible,
+}
+
+; --- WebSocket-only subscription commands ---
+
+SubscriptionCommand = (
+  subscription.subscribe //
+  subscription.unsubscribe //
+  subscription.reconnect
+)
+
+subscription.subscribe = {
+  method: "subscription.subscribe",
+  params: SubscribeParams,
+}
+
+SubscribeParams = {
+  channels: [+ Channel],
+  ? namespaces: [* Namespace],           ; Prefix-match these namespace paths
+  ? depth: uint,                         ; Max depth below namespace prefix
+  Extensible,
+}
+
+SubscribeResult = {
+  subscriptionId: text,
+  ? replayedEvents: uint,               ; Events replayed from buffer
+  Extensible,
+}
+
+subscription.unsubscribe = {
+  method: "subscription.unsubscribe",
+  params: UnsubscribeParams,
+}
+
+UnsubscribeParams = {
+  subscriptionId: text,
+  Extensible,
+}
+
+subscription.reconnect = {
+  method: "subscription.reconnect",
+  params: ReconnectParams,
+}
+
+ReconnectParams = {
+  runId: text,
+  ? lastEventId: text,                  ; Last event the client processed
+  ? subscriptions: [* text],            ; Subscription IDs to restore
+  Extensible,
+}
+
+ReconnectResult = {
+  restored: bool,
+  ? missedEvents: uint,
+  ? currentNamespaces: [* AgentStatusEntry],
+  Extensible,
+}
+
+AgentStatusEntry = {
+  namespace: Namespace,
+  status: AgentStatus,
+  Extensible,
+}
+
+SubscriptionResult = SubscribeResult / ReconnectResult / EmptyResult
+
+
+; ==========================================================================
+; 7. Agent / Lifecycle Module
+;
+; Hierarchy discovery and lifecycle tracking. The lifecycle channel
+; tracks the status of every namespace in the agent tree and provides
+; parent→child correlation for subgraph discovery via the `cause`
+; field on `started` events.
+; See proposal §17 (Channel Architecture) for the design rationale.
+; ==========================================================================
+
+AgentCommand = agent.getTree
+
+; --- agent.getTree ---
+
+agent.getTree = {
+  method: "agent.getTree",
+  params: AgentGetTreeParams,
+}
+
+AgentGetTreeParams = {
+  ? runId: text,
+}
+
+AgentTreeNode = {
+  namespace: Namespace,
+  status: AgentStatus,
+  graphName: text,
+  ? children: [* AgentTreeNode],
+  ? metadata: {* text => any},
+}
+
+AgentResult = {
+  tree: AgentTreeNode,
+}
+
+AgentStatus = "started"
+            / "running"
+            / "completed"
+            / "failed"
+            / "interrupted"
+
+
+; --- Event registry ---
+;
+; All server -> client events are registered here as a group choice.
+
+EventData = (
+  LifecycleEvent //
+  MessagesEvent //
+  ToolsEvent //
+  InputEvent //
+  ValuesEvent //
+  UpdatesEvent //
+  CheckpointsEvent //
+  CustomEvent //
+  TasksEvent
+)
+
+
+; --- Lifecycle events (server -> client, channel: "lifecycle") ---
+;
+; Lifecycle events track the status of the root run and all subgraphs.
+; The optional `cause` field on `started` events correlates a child
+; namespace back to whatever on the parent namespace triggered it,
+; enabling over-the-wire clients to reconstruct the subgraph tree
+; without product-specific knowledge.
+
+LifecycleEvent = {
+  method: "lifecycle",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: LifecycleData,
+  },
+}
+
+; Causation edge for a subgraph's `started` lifecycle event.
+;
+; Identifies what on the parent namespace caused this subgraph to
+; start. Populated by product-specific stream transformers (e.g.
+; deepagents' SubagentTransformer) before events reach the wire.
+; langgraph core and langgraph-api are product-agnostic and do not
+; populate this field. Optional — absent for the root graph and
+; for subgraphs whose spawning mechanism isn't yet modelled.
+;
+; Extensible via new variants; consumers MUST default-case unknown
+; `type` values to "unknown cause" rather than erroring, so future
+; additions don't break pinned clients.
+LifecycleCause = LifecycleCauseToolCall / LifecycleCauseSend / LifecycleCauseEdge
+
+; A tool call on the parent namespace spawned this subgraph.
+;
+; How it's produced in code:
+;   A tool node's handler body invokes a compiled subgraph — e.g.
+;   `await subagent.ainvoke(...)` or `subagent.astream(...)` from
+;   inside a `@tool`-decorated function. Deepagents' `task` tool
+;   is the canonical example: it calls `subagent.ainvoke(input)`
+;   to execute a nested agent, and each call becomes one subgraph
+;   run correlated back to the originating `tool_call_id`.
+;
+; Populated by: product-specific stream transformer (e.g.
+;   deepagents' SubagentTransformer / createSubagentTransformer).
+LifecycleCauseToolCall = {
+  type: "toolCall",
+  ; The `tool_call_id` from the originating `tool-started` event
+  ; on the parent namespace. Matches the `id` field of the
+  ; originating `tool_call` content block in the parent AI message.
+  toolCallId: text,
+}
+
+; A `Send` dispatched from a parent node spawned this subgraph.
+;
+; How it's produced in code:
+;   A parent node returns/yields one or more `Send(node, state)`
+;   objects (langgraph's fan-out primitive). Each `Send` creates a
+;   parallel pregel task; when the target node embeds a compiled
+;   subgraph, each `Send` instance spawns its own subgraph run.
+;   Typical in supervisor/worker patterns where the supervisor
+;   yields `Send("worker", work_item)` once per item.
+;
+; Populated by: (no transformer in current releases; declared for
+;   future supervisor-pattern transformers to emit).
+LifecycleCauseSend = {
+  type: "send",
+  ; Name of the parent node that issued the `Send`. Multiple Sends
+  ; from the same node in the same superstep share this value;
+  ; future protocol versions may add a disambiguating `sendIndex`
+  ; if per-Send identity is needed on the wire.
+  fromNode: text,
+}
+
+; A graph edge transitioned into this subgraph's entry node.
+;
+; How it's produced in code:
+;   A static edge (`graph.add_edge("a", "b")`) or a conditional
+;   edge (`graph.add_conditional_edges("a", router_fn)`) routes
+;   control into a node that embeds a compiled subgraph. Unlike
+;   `Send`, edge transitions are single-successor and do not
+;   fan out — one edge traversal produces exactly one subgraph run.
+;
+; Populated by: (no transformer in current releases; declared for
+;   future embedded-subgraph transformers to emit).
+LifecycleCauseEdge = {
+  type: "edge",
+  ; Name of the parent node the edge originated from.
+  fromNode: text,
+}
+
+LifecycleData = {
+  event: AgentStatus,
+  ? graphName: text,
+  ? cause: LifecycleCause,               ; Causation edge (see LifecycleCause)
+  ? error: text,
+  ? checkpoint: CheckpointRef,           ; Checkpoint reference for time-travel
+}
+
+
+; ==========================================================================
+; 8. Messages Module
+;
+; Content-block-centric transcript message streaming. AI-authored messages
+; may stream incrementally; human/system messages are typically replayed
+; as complete messages. Events follow a strict lifecycle:
+;
+;   message-start
+;     -> content-block-start(index=0, contentBlock)
+;       -> content-block-delta(index=0, contentBlock) ...
+;     -> content-block-finish(index=0, contentBlock)
+;     -> content-block-start(index=1, contentBlock)
+;       -> content-block-delta(index=1, contentBlock) ...
+;     -> content-block-finish(index=1, contentBlock)
+;   -> message-finish(reason)
+;
+; Content blocks MUST NOT interleave: block N must finish before block
+; N+1 starts. This constraint applies within a single message
+; (identified by namespace + node) and matches observed behavior of
+; all major LLM providers.
+;
+; Delta events carry LangChain ContentBlock instances directly —
+; the block's `type` field is the discriminant. This means adding
+; a new content block type to LangChain requires zero protocol changes.
+; ==========================================================================
+
+MessagesEvent = {
+  method: "messages",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    ? node: text,                        ; Graph node that produced this event
+    data: MessagesData,
+  },
+}
+
+MessagesData = MessageStartData
+             / ContentBlockStartData
+             / ContentBlockDeltaData
+             / ContentBlockFinishData
+             / MessageFinishData
+             / MessageErrorData
+
+; Emitted once at the start of a streamed or replayed transcript message.
+MessageStartData = {
+  event: "message-start",
+  role: MessageRole,                     ; Author role for this message
+  id: text,                              ; Unique ID for this message
+  ? metadata: MessageMetadata,           ; Concise provider/model metadata for AI messages
+  Extensible,
+}
+
+; Emitted when a new content block begins streaming. The contentBlock
+; carries the initial state (e.g. { type: "text", text: "" } or
+; { type: "tool_call_chunk", name: "search", args: "" }).
+ContentBlockStartData = {
+  event: "content-block-start",
+  index: uint,                           ; Positional index within the message
+  content: ContentBlock,
+  Extensible,
+}
+
+; Emitted for each incremental update within a content block. The
+; contentBlock carries only the delta for this update:
+;   { type: "text", text: "Hello " }           — text delta
+;   { type: "reasoning", reasoning: "Let me" } — reasoning delta
+;   { type: "tool_call_chunk", args: '{"q":' } — tool call args delta
+ContentBlockDeltaData = {
+  event: "content-block-delta",
+  index: uint,
+  content: ContentBlock,
+  Extensible,
+}
+
+; Emitted when a content block is complete. The contentBlock carries
+; the finalized block. For tool calls, this upgrades ToolCallChunk
+; to ToolCall with parsed args.
+ContentBlockFinishData = {
+  event: "content-block-finish",
+  index: uint,
+  content: FinalizedContentBlock,
+  Extensible,
+}
+
+; Emitted once when the message is complete.
+MessageFinishData = {
+  event: "message-finish",
+  ? usage: UsageInfo,                    ; Token usage for AI-authored messages
+  Extensible,
+}
+
+UsageInfo = {
+  ? inputTokens: uint,
+  ? outputTokens: uint,
+  ? totalTokens: uint,
+  Extensible,
+}
+
+; Emitted on unrecoverable errors within a model call.
+MessageErrorData = {
+  event: "error",
+  message: text,
+  ? code: text,
+  Extensible,
+}
+
+
+; ==========================================================================
+; 9. Tools Module
+;
+; Tool execution lifecycle observability. Events cover the full
+; lifecycle of a tool invocation:
+;
+;   tool-started(toolCallId, toolName)
+;     -> tool-output-delta(toolCallId, delta) ...  (optional, streaming tools)
+;   -> tool-finished(toolCallId, output)
+;      | tool-error(toolCallId, message)
+; ==========================================================================
+
+ToolsEvent = {
+  method: "tools",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    ? node: text,                        ; Graph node executing the tool
+    data: ToolsData,
+  },
+}
+
+ToolsData = ToolStartedData
+          / ToolOutputDeltaData
+          / ToolFinishedData
+          / ToolErrorData
+
+; Emitted when tool execution begins.
+ToolStartedData = {
+  event: "tool-started",
+  toolCallId: text,
+  toolName: text,
+  ? input: any,                          ; Tool input arguments
+  Extensible,
+}
+
+; Emitted for incremental tool output (for tools that stream results).
+ToolOutputDeltaData = {
+  event: "tool-output-delta",
+  toolCallId: text,
+  delta: text,
+  Extensible,
+}
+
+; Emitted when tool execution completes successfully.
+ToolFinishedData = {
+  event: "tool-finished",
+  toolCallId: text,
+  output: any,
+  Extensible,
+}
+
+; Emitted when tool execution fails.
+ToolErrorData = {
+  event: "tool-error",
+  toolCallId: text,
+  message: text,
+  ? code: text,
+  Extensible,
+}
+
+
+; ==========================================================================
+; 10. Input Module
+;
+; Human-in-the-loop. Wraps LangGraph's interrupt() / Command({ resume })
+; as in-band protocol messages. Also supports unsolicited user input
+; injection while the agent is running.
+; ==========================================================================
+
+InputCommand = (
+  input.respond //
+  input.inject
+)
+
+; --- input.respond ---
+
+input.respond = {
+  method: "input.respond",
+  params: InputRespondParams,
+}
+
+InputRespondParams = {
+  namespace: Namespace,
+  interruptId: text,
+  response: any,
+}
+
+; --- input.inject ---
+
+input.inject = {
+  method: "input.inject",
+  params: InputInjectParams,
+}
+
+InputInjectParams = {
+  namespace: Namespace,
+  message: InputMessage,
+}
+
+InputMessage = {
+  role: "user" / "system",
+  content: text,
+  ? name: text,
+  Extensible,
+}
+
+InputResult = EmptyResult
+
+; --- Input events (server -> client, channel: "input") ---
+
+InputEvent = {
+  method: "input.requested",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: InputRequestedData,
+  },
+}
+
+InputRequestedData = {
+  interruptId: text,                      ; Correlates this request with input.respond
+  payload: any,                           ; Opaque interrupt value from runtime; application-defined shape
+  Extensible,
+}
+
+
+; ==========================================================================
+; 11. State Module
+;
+; Graph state and checkpoint access. Enables state inspection and
+; time-travel debugging (fork from checkpoint).
+;
+; Note: Cross-thread store operations (search, put) are accessed via
+; the LangGraph REST API and are not part of the streaming protocol.
+; ==========================================================================
+
+StateCommand = (
+  state.get //
+  state.listCheckpoints //
+  state.fork
+)
+
+; --- state.get ---
+
+state.get = {
+  method: "state.get",
+  params: StateGetParams,
+}
+
+StateGetParams = {
+  namespace: Namespace,
+  ? keys: [* text],                      ; Specific state keys, or omit for all
+}
+
+StateGetResult = {
+  values: {* text => any},
+  ? checkpoint: CheckpointRef,
+}
+
+; --- state.listCheckpoints ---
+
+state.listCheckpoints = {
+  method: "state.listCheckpoints",
+  params: ListCheckpointsParams,
+}
+
+ListCheckpointsParams = {
+  ? namespace: Namespace,
+  ? limit: uint,
+  ? before: text,                        ; Cursor for pagination
+}
+
+ListCheckpointsResult = {
+  checkpoints: [* CheckpointSummary],
+}
+
+CheckpointSummary = {
+  id: text,
+  timestamp: text,                       ; ISO 8601
+  step: uint,
+  ? nodeName: text,                      ; Node that produced this checkpoint
+  ? metadata: {* text => any},
+}
+
+CheckpointRef = {
+  id: text,
+  ? ns: text,
+}
+
+; --- state.fork ---
+
+state.fork = {
+  method: "state.fork",
+  params: StateForkParams,
+}
+
+StateForkParams = {
+  checkpointId: text,
+  ? input: any,                          ; Input for the forked run
+  ? config: {* text => any},             ; Config overrides
+}
+
+StateForkResult = {
+  runId: text,
+  threadId: text,
+}
+
+StateResult = StateGetResult
+            / ListCheckpointsResult / StateForkResult / EmptyResult
+
+
+; ==========================================================================
+; 12. Passthrough Channels
+;
+; These channels carry payloads shaped by the LangGraph runtime and
+; user graph schemas. Their data shapes are intentionally open
+; because they depend on the user's graph state definition.
+;
+; The `values` channel doubles as the "values snapshot" mechanism:
+; when a subscription is created, the first event replayed is the
+; current full state, giving consumers a consistent baseline to
+; apply subsequent deltas against.
+;
+; The `checkpoints` channel carries a lightweight envelope (id,
+; parentId, step, source) emitted once per persisted checkpoint.
+; Clients reconstruct a branching/time-travel history from this
+; metadata alone — the envelope provides the fork target (`id`),
+; tree linkage (`parentId`), and timeline sort/label (`step`,
+; `source`). Full channel state is retrieved lazily via `state.get`
+; or bulk via `state.listCheckpoints`, only for the checkpoints the
+; client actually inspects. Clients that want state snapshots
+; alongside the timeline subscribe to both `values` and
+; `checkpoints`; clients that only need timeline metadata pay only
+; the envelope cost.
+; ==========================================================================
+
+; --- values (channel: "values") ---
+; Full graph state after each step or initial snapshot.
+ValuesEvent = {
+  method: "values",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: any,                           ; Full graph state after step
+  },
+}
+
+; --- checkpoints (channel: "checkpoints") ---
+; Lightweight checkpoint metadata emitted once per persisted
+; checkpoint. Carries only the envelope needed to build a
+; branching/time-travel UI and to target `state.fork`; full
+; channel state is retrieved on demand via `state.get` /
+; `state.listCheckpoints`.
+;
+; A `checkpoints` event is emitted on the same superstep as the
+; corresponding `values` event; clients that subscribe to both can
+; correlate the pair by (namespace, step) or by adjacent `seq`
+; numbers on the outer event envelope.
+CheckpointsEvent = {
+  method: "checkpoints",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: Checkpoint,
+  },
+}
+
+; Lightweight checkpoint envelope. Supplies just enough metadata
+; for clients to build a branching/time-travel UI without streaming
+; full channel snapshots.
+Checkpoint = {
+  id: text,                              ; Fork target: pass to state.fork / configurable.checkpoint_id
+  ? parentId: text,                      ; Parent checkpoint id for tree linkage
+  step: int,                             ; Superstep number (-1 for first input, 0 for first loop step, ...)
+  source: CheckpointSource,              ; Origin of the checkpoint
+  Extensible,
+}
+
+; Origin tag matching LangGraph's CheckpointMetadata.source.
+CheckpointSource = "input"               ; Created from invoke/stream/batch input
+                 / "loop"                ; Created inside the pregel loop
+                 / "update"              ; Created from a manual state update
+                 / "fork"                ; Created as a copy of another checkpoint
+
+; --- updates (channel: "updates") ---
+; Per-node state deltas.
+UpdatesEvent = {
+  method: "updates",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: UpdatesData,
+  },
+}
+
+UpdatesData = {
+  ? node: text,                          ; Graph node that produced this update
+  values: {* text => any},              ; State delta
+  Extensible,
+}
+
+; --- custom (channel: "custom") ---
+; User-defined payloads emitted via config.writer / getWriter().
+CustomEvent = {
+  method: "custom",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: CustomData,
+  },
+}
+
+CustomData = {
+  ? name: text,                          ; Custom event name for dispatch
+  payload: any,                          ; User-defined payload
+  Extensible,
+}
+
+; --- tasks (channel: "tasks") ---
+; Pregel task creation or result events from the graph runtime.
+TasksEvent = {
+  method: "tasks",
+  params: {
+    namespace: Namespace,
+    timestamp: Timestamp,
+    data: any,                           ; Task creation or result
+  },
+}

--- a/streaming/py/LICENSE
+++ b/streaming/py/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LangChain, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/streaming/py/README.md
+++ b/streaming/py/README.md
@@ -1,11 +1,18 @@
 # langchain-protocol
 
-Python bindings for the LangChain agent streaming protocol.
+Python bindings for the [LangChain agent streaming protocol][streaming].
 
 This package provides generated `TypedDict` and `Literal` definitions for the
 protocol's commands, events, results, and payload shapes. It does not include a
 runtime client, transport, or helper APIs &mdash; it is intended as a source of
 typing primitives only.
+
+The types are generated from [`protocol.cddl`][cddl], the source of truth for
+the wire format. See the [streaming protocol overview][streaming] for the
+full design, channel model, and transport details.
+
+[streaming]: https://github.com/langchain-ai/agent-protocol/tree/main/streaming
+[cddl]: https://github.com/langchain-ai/agent-protocol/blob/main/streaming/protocol.cddl
 
 ## Installation
 

--- a/streaming/py/README.md
+++ b/streaming/py/README.md
@@ -1,0 +1,36 @@
+# langchain-protocol
+
+Python bindings for the LangChain agent streaming protocol.
+
+This package provides generated `TypedDict` and `Literal` definitions for the
+protocol's commands, events, results, and payload shapes. It does not include a
+runtime client, transport, or helper APIs &mdash; it is intended as a source of
+typing primitives only.
+
+## Installation
+
+```bash
+pip install langchain-protocol
+```
+
+## Usage
+
+```python
+from langchain_protocol import Command, SubscribeParams
+
+params: SubscribeParams = {
+    "channels": ["messages", "lifecycle"],
+}
+
+subscribe: Command = {
+    "id": 1,
+    "method": "subscription.subscribe",
+    "params": params,
+}
+```
+
+## What this package includes
+
+- `TypedDict` definitions for commands, events, results, and payload shapes
+- `Literal` and union aliases for protocol enums and tagged unions
+- A `py.typed` marker so type checkers pick up the bundled annotations

--- a/streaming/py/langchain_protocol/__init__.py
+++ b/streaming/py/langchain_protocol/__init__.py
@@ -1,0 +1,3 @@
+"""Python bindings for the LangChain agent streaming protocol."""
+
+from langchain_protocol.protocol import *  # noqa: F403

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -1,0 +1,556 @@
+# compiled with https://www.npmjs.com/package/cddl2py v0.2.2
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Union
+from typing_extensions import NotRequired, TypedDict
+
+JsInt = int
+
+JsUint = int
+
+Namespace = list[str]
+
+Extensible = dict[str, Any]
+
+Timestamp = int
+
+MetadataScalar = Union[None, bool, int, float, str]
+
+MessageRole = Union[Literal["ai"], Literal["human"], Literal["system"]]
+
+class MessageMetadata(TypedDict, extra_items=MetadataScalar):
+    provider: NotRequired[str]
+    model: NotRequired[str]
+    model_type: NotRequired[str]
+    run_id: NotRequired[str]
+    thread_id: NotRequired[str]
+    system_fingerprint: NotRequired[str]
+    service_tier: NotRequired[str]
+
+class TextContentBlock(TypedDict):
+    type: Literal["text"]
+    text: str
+    id: NotRequired[str]
+    index: NotRequired[BlockIndex]
+    annotations: NotRequired[list[Annotation]]
+
+class InvalidToolCall(TypedDict):
+    type: Literal["invalid_tool_call"]
+    id: Union[str, None]
+    name: Union[str, None]
+    args: Union[str, None]
+    error: Union[str, None]
+    index: NotRequired[BlockIndex]
+
+class ReasoningContentBlock(TypedDict):
+    type: Literal["reasoning"]
+    reasoning: NotRequired[str]
+    id: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+class NonStandardContentBlock(TypedDict):
+    type: Literal["non_standard"]
+    value: dict[str, Any]
+    id: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+class ImageContentBlock(TypedDict):
+    type: Literal["image"]
+    id: NotRequired[str]
+    file_id: NotRequired[str]
+    url: NotRequired[str]
+    base64: NotRequired[str]  # Base64-encoded image data
+    mime_type: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+class VideoContentBlock(TypedDict):
+    type: Literal["video"]
+    id: NotRequired[str]
+    file_id: NotRequired[str]
+    url: NotRequired[str]
+    base64: NotRequired[str]  # Base64-encoded video data
+    mime_type: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+class AudioContentBlock(TypedDict):
+    type: Literal["audio"]
+    id: NotRequired[str]
+    file_id: NotRequired[str]
+    url: NotRequired[str]
+    base64: NotRequired[str]  # Base64-encoded audio data
+    mime_type: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+class FileContentBlock(TypedDict):
+    type: Literal["file"]
+    id: NotRequired[str]
+    file_id: NotRequired[str]
+    url: NotRequired[str]
+    base64: NotRequired[str]  # Base64-encoded file data
+    mime_type: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+DataContentBlock = Union[ImageContentBlock, VideoContentBlock, AudioContentBlock, FileContentBlock]
+
+class ToolCall(TypedDict):
+    type: Literal["tool_call"]
+    id: Union[str, None]
+    name: str
+    args: dict[str, Any]
+    index: NotRequired[BlockIndex]
+
+class ToolCallChunk(TypedDict):
+    type: Literal["tool_call_chunk"]
+    id: Union[str, None]
+    name: Union[str, None]
+    args: Union[str, None]  # Partial JSON string
+    index: NotRequired[BlockIndex]
+
+class ServerToolCall(TypedDict):
+    type: Literal["server_tool_call"]
+    id: str
+    name: str
+    args: dict[str, Any]
+    index: NotRequired[BlockIndex]
+
+class ServerToolCallChunk(TypedDict):
+    type: Literal["server_tool_call_chunk"]
+    id: NotRequired[str]
+    name: NotRequired[str]
+    args: NotRequired[str]
+    index: NotRequired[BlockIndex]
+
+class ServerToolResult(TypedDict):
+    type: Literal["server_tool_result"]
+    tool_call_id: str
+    status: Union[Literal["success"], Literal["error"]]
+    id: NotRequired[str]
+    output: NotRequired[Any]
+    index: NotRequired[BlockIndex]
+
+ToolContentBlock = Union[ToolCall, ToolCallChunk, ServerToolCall, ServerToolCallChunk, ServerToolResult]
+
+ContentBlock = Union[TextContentBlock, InvalidToolCall, ReasoningContentBlock, NonStandardContentBlock, DataContentBlock, ToolContentBlock]
+
+FinalizedContentBlock = Union[TextContentBlock, ReasoningContentBlock, ToolCall, InvalidToolCall, ServerToolCall, ServerToolResult, DataContentBlock, NonStandardContentBlock]
+
+BlockIndex = Union[JsInt, str]
+
+class Citation(TypedDict):
+    type: Literal["citation"]
+    id: NotRequired[str]
+    url: NotRequired[str]
+    title: NotRequired[str]
+    start_index: NotRequired[int]
+    end_index: NotRequired[int]
+    cited_text: NotRequired[str]
+
+class NonStandardAnnotation(TypedDict):
+    type: Literal["non_standard_annotation"]
+    id: NotRequired[str]
+    value: dict[str, Any]
+
+Annotation = Union[Citation, NonStandardAnnotation]
+
+class RunInput(TypedDict):
+    method: Literal["run.input"]
+    params: RunInputParams
+
+class SubscriptionSubscribe(TypedDict):
+    method: Literal["subscription.subscribe"]
+    params: SubscribeParams
+
+class SubscriptionUnsubscribe(TypedDict):
+    method: Literal["subscription.unsubscribe"]
+    params: UnsubscribeParams
+
+class SubscriptionReconnect(TypedDict):
+    method: Literal["subscription.reconnect"]
+    params: ReconnectParams
+
+SubscriptionCommand = Union[SubscriptionSubscribe, SubscriptionUnsubscribe, SubscriptionReconnect]
+
+class AgentGetTree(TypedDict):
+    method: Literal["agent.getTree"]
+    params: AgentGetTreeParams
+
+class InputRespond(TypedDict):
+    method: Literal["input.respond"]
+    params: InputRespondParams
+
+class InputInject(TypedDict):
+    method: Literal["input.inject"]
+    params: InputInjectParams
+
+InputCommand = Union[InputRespond, InputInject]
+
+class StateGet(TypedDict):
+    method: Literal["state.get"]
+    params: StateGetParams
+
+class StateListCheckpoints(TypedDict):
+    method: Literal["state.listCheckpoints"]
+    params: ListCheckpointsParams
+
+class StateFork(TypedDict):
+    method: Literal["state.fork"]
+    params: StateForkParams
+
+StateCommand = Union[StateGet, StateListCheckpoints, StateFork]
+
+class _CommandFields(TypedDict):
+    id: JsUint
+
+class _CommandVariant1(_CommandFields, SubscriptionSubscribe):
+    pass
+
+class _CommandVariant2(_CommandFields, SubscriptionUnsubscribe):
+    pass
+
+class _CommandVariant3(_CommandFields, SubscriptionReconnect):
+    pass
+
+class _CommandVariant5(_CommandFields, InputRespond):
+    pass
+
+class _CommandVariant6(_CommandFields, InputInject):
+    pass
+
+class _CommandVariant7(_CommandFields, StateGet):
+    pass
+
+class _CommandVariant8(_CommandFields, StateListCheckpoints):
+    pass
+
+class _CommandVariant9(_CommandFields, StateFork):
+    pass
+
+class CommandResponse(TypedDict):
+    type: Literal["success"]
+    id: JsUint
+    result: ResultData
+    meta: NotRequired[ResponseMeta]
+
+class ErrorResponse(TypedDict):
+    type: Literal["error"]
+    id: Union[JsUint, None]
+    error: ErrorCode
+    message: str
+    stacktrace: NotRequired[str]
+    meta: NotRequired[ResponseMeta]
+
+class LifecycleEvent(TypedDict):
+    method: Literal["lifecycle"]
+    params: dict[str, Any]
+
+class MessagesEvent(TypedDict):
+    method: Literal["messages"]
+    params: dict[str, Any]
+
+class ToolsEvent(TypedDict):
+    method: Literal["tools"]
+    params: dict[str, Any]
+
+class InputEvent(TypedDict):
+    method: Literal["input.requested"]
+    params: dict[str, Any]
+
+class ValuesEvent(TypedDict):
+    method: Literal["values"]
+    params: dict[str, Any]
+
+class UpdatesEvent(TypedDict):
+    method: Literal["updates"]
+    params: dict[str, Any]
+
+class CheckpointsEvent(TypedDict):
+    method: Literal["checkpoints"]
+    params: dict[str, Any]
+
+class CustomEvent(TypedDict):
+    method: Literal["custom"]
+    params: dict[str, Any]
+
+class TasksEvent(TypedDict):
+    method: Literal["tasks"]
+    params: dict[str, Any]
+
+EventData = Union[LifecycleEvent, MessagesEvent, ToolsEvent, InputEvent, ValuesEvent, UpdatesEvent, CheckpointsEvent, CustomEvent, TasksEvent]
+
+class _EventFields(TypedDict):
+    type: Literal["event"]
+    event_id: NotRequired[str]  # Unique ID for reconnection (maps to SSE id:)
+    seq: NotRequired[JsUint]  # Monotonic sequence number for ordering
+
+class _EventVariant0(_EventFields, LifecycleEvent):
+    pass
+
+class _EventVariant1(_EventFields, MessagesEvent):
+    pass
+
+class _EventVariant2(_EventFields, ToolsEvent):
+    pass
+
+class _EventVariant3(_EventFields, InputEvent):
+    pass
+
+class _EventVariant4(_EventFields, ValuesEvent):
+    pass
+
+class _EventVariant5(_EventFields, UpdatesEvent):
+    pass
+
+class _EventVariant6(_EventFields, CheckpointsEvent):
+    pass
+
+class _EventVariant7(_EventFields, CustomEvent):
+    pass
+
+class _EventVariant8(_EventFields, TasksEvent):
+    pass
+
+Event = Union[_EventVariant0, _EventVariant1, _EventVariant2, _EventVariant3, _EventVariant4, _EventVariant5, _EventVariant6, _EventVariant7, _EventVariant8]
+
+Message = Union[CommandResponse, ErrorResponse, Event]
+
+class RunResult(TypedDict):
+    run_id: NotRequired[str]  # ID of the started or resumed run
+
+class SubscribeResult(TypedDict):
+    subscription_id: str
+    replayed_events: NotRequired[int]  # Events replayed from buffer
+
+class ReconnectResult(TypedDict):
+    restored: bool
+    missed_events: NotRequired[int]
+    current_namespaces: NotRequired[list[AgentStatusEntry]]
+
+class EmptyResult(TypedDict):
+    pass
+
+class AgentResult(TypedDict):
+    tree: AgentTreeNode
+
+class StateGetResult(TypedDict):
+    values: dict[str, Any]
+    checkpoint: NotRequired[CheckpointRef]
+
+class ListCheckpointsResult(TypedDict):
+    checkpoints: list[CheckpointSummary]
+
+class StateForkResult(TypedDict):
+    run_id: str
+    thread_id: str
+
+ErrorCode = Union[Literal["invalid_argument"], Literal["unknown_command"], Literal["unknown_error"], Literal["no_such_run"], Literal["no_such_subscription"], Literal["no_such_namespace"], Literal["no_such_interrupt"], Literal["no_such_checkpoint"], Literal["permission_denied"], Literal["not_supported"]]
+
+class ResponseMeta(TypedDict):
+    applied_through_seq: NotRequired[JsUint]
+
+RunCommand = RunInput
+
+class _CommandVariant0(_CommandFields, RunCommand):
+    pass
+
+class RunInputParams(TypedDict):
+    assistant_id: str  # Deployed graph/agent to run
+    input: Any  # Graph input, resume value, or injected message
+    config: NotRequired[dict[str, Any]]  # Per-run config overrides
+    metadata: NotRequired[dict[str, Any]]  # Per-run metadata
+
+Channel = Union[Literal["values"], Literal["updates"], Literal["messages"], Literal["tools"], Literal["lifecycle"], Literal["input"], Literal["checkpoints"], Literal["tasks"], Literal["custom"], Annotated[str, "custom:.+"]]
+
+class EventStreamRequest(TypedDict):
+    channels: list[Channel]
+    namespaces: NotRequired[list[Namespace]]  # Prefix-match these namespace paths
+    depth: NotRequired[int]  # Max depth below namespace prefix
+    since: NotRequired[JsUint]  # Replay events after this seq number
+
+class SubscribeParams(TypedDict):
+    channels: list[Channel]
+    namespaces: NotRequired[list[Namespace]]  # Prefix-match these namespace paths
+    depth: NotRequired[int]  # Max depth below namespace prefix
+
+class UnsubscribeParams(TypedDict):
+    subscription_id: str
+
+class ReconnectParams(TypedDict):
+    run_id: str
+    last_event_id: NotRequired[str]  # Last event the client processed
+    subscriptions: NotRequired[list[str]]  # Subscription IDs to restore
+
+class AgentStatusEntry(TypedDict):
+    namespace: Namespace
+    status: AgentStatus
+
+SubscriptionResult = Union[SubscribeResult, ReconnectResult, EmptyResult]
+
+AgentCommand = AgentGetTree
+
+CommandData = Union[RunCommand, SubscriptionCommand, AgentCommand, InputCommand, StateCommand]
+
+class _CommandVariant4(_CommandFields, AgentCommand):
+    pass
+
+Command = Union[_CommandVariant0, _CommandVariant1, _CommandVariant2, _CommandVariant3, _CommandVariant4, _CommandVariant5, _CommandVariant6, _CommandVariant7, _CommandVariant8, _CommandVariant9]
+
+class AgentGetTreeParams(TypedDict):
+    run_id: NotRequired[str]
+
+class AgentTreeNode(TypedDict):
+    namespace: Namespace
+    status: AgentStatus
+    graph_name: str
+    children: NotRequired[list[AgentTreeNode]]
+    metadata: NotRequired[dict[str, Any]]
+
+AgentStatus = Union[Literal["started"], Literal["running"], Literal["completed"], Literal["failed"], Literal["interrupted"]]
+
+class LifecycleCauseToolCall(TypedDict):
+    type: Literal["toolCall"]  # The `tool_call_id` from the originating `tool-started` event
+    tool_call_id: str
+
+class LifecycleCauseSend(TypedDict):
+    type: Literal["send"]  # Name of the parent node that issued the `Send`. Multiple Sends
+    from_node: str
+
+class LifecycleCauseEdge(TypedDict):
+    type: Literal["edge"]  # Name of the parent node the edge originated from.
+    from_node: str
+
+LifecycleCause = Union[LifecycleCauseToolCall, LifecycleCauseSend, LifecycleCauseEdge]
+
+class LifecycleData(TypedDict):
+    event: AgentStatus
+    graph_name: NotRequired[str]
+    cause: NotRequired[LifecycleCause]  # Causation edge (see LifecycleCause)
+    error: NotRequired[str]
+    checkpoint: NotRequired[CheckpointRef]  # Checkpoint reference for time-travel
+
+class MessageStartData(TypedDict):
+    event: Literal["message-start"]
+    role: MessageRole  # Author role for this message
+    id: str  # Unique ID for this message
+    metadata: NotRequired[MessageMetadata]  # Concise provider/model metadata for AI messages
+
+class ContentBlockStartData(TypedDict):
+    event: Literal["content-block-start"]
+    index: int  # Positional index within the message
+    content: ContentBlock
+
+class ContentBlockDeltaData(TypedDict):
+    event: Literal["content-block-delta"]
+    index: int
+    content: ContentBlock
+
+class ContentBlockFinishData(TypedDict):
+    event: Literal["content-block-finish"]
+    index: int
+    content: FinalizedContentBlock
+
+class MessageFinishData(TypedDict):
+    event: Literal["message-finish"]
+    usage: NotRequired[UsageInfo]  # Token usage for AI-authored messages
+
+class MessageErrorData(TypedDict):
+    event: Literal["error"]
+    message: str
+    code: NotRequired[str]
+
+MessagesData = Union[MessageStartData, ContentBlockStartData, ContentBlockDeltaData, ContentBlockFinishData, MessageFinishData, MessageErrorData]
+
+class UsageInfo(TypedDict):
+    input_tokens: NotRequired[int]
+    output_tokens: NotRequired[int]
+    total_tokens: NotRequired[int]
+
+class ToolStartedData(TypedDict):
+    event: Literal["tool-started"]
+    tool_call_id: str
+    tool_name: str
+    input: NotRequired[Any]  # Tool input arguments
+
+class ToolOutputDeltaData(TypedDict):
+    event: Literal["tool-output-delta"]
+    tool_call_id: str
+    delta: str
+
+class ToolFinishedData(TypedDict):
+    event: Literal["tool-finished"]
+    tool_call_id: str
+    output: Any
+
+class ToolErrorData(TypedDict):
+    event: Literal["tool-error"]
+    tool_call_id: str
+    message: str
+    code: NotRequired[str]
+
+ToolsData = Union[ToolStartedData, ToolOutputDeltaData, ToolFinishedData, ToolErrorData]
+
+class InputRespondParams(TypedDict):
+    namespace: Namespace
+    interrupt_id: str
+    response: Any
+
+class InputInjectParams(TypedDict):
+    namespace: Namespace
+    message: InputMessage
+
+class InputMessage(TypedDict):
+    role: Union[Literal["user"], Literal["system"]]
+    content: str
+    name: NotRequired[str]
+
+InputResult = EmptyResult
+
+class InputRequestedData(TypedDict):
+    interrupt_id: str  # Correlates this request with input.respond
+    payload: Any  # Opaque interrupt value from runtime; application-defined shape
+
+class StateGetParams(TypedDict):
+    namespace: Namespace
+    keys: NotRequired[list[str]]  # Specific state keys, or omit for all
+
+class ListCheckpointsParams(TypedDict):
+    namespace: NotRequired[Namespace]
+    limit: NotRequired[int]
+    before: NotRequired[str]  # Cursor for pagination
+
+class CheckpointSummary(TypedDict):
+    id: str
+    timestamp: str  # ISO 8601
+    step: int
+    node_name: NotRequired[str]  # Node that produced this checkpoint
+    metadata: NotRequired[dict[str, Any]]
+
+class CheckpointRef(TypedDict):
+    id: str
+    ns: NotRequired[str]
+
+class StateForkParams(TypedDict):
+    checkpoint_id: str
+    input: NotRequired[Any]  # Input for the forked run
+    config: NotRequired[dict[str, Any]]  # Config overrides
+
+StateResult = Union[StateGetResult, ListCheckpointsResult, StateForkResult, EmptyResult]
+
+ResultData = Union[RunResult, SubscriptionResult, AgentResult, InputResult, StateResult, EmptyResult]
+
+class Checkpoint(TypedDict):
+    id: str  # Fork target: pass to state.fork / configurable.checkpoint_id
+    parent_id: NotRequired[str]  # Parent checkpoint id for tree linkage
+    step: int  # Superstep number (-1 for first input, 0 for first loop step, ...)
+    source: CheckpointSource  # Origin of the checkpoint
+
+CheckpointSource = Union[Literal["input"], Literal["loop"], Literal["update"], Literal["fork"]]
+
+class UpdatesData(TypedDict):
+    node: NotRequired[str]  # Graph node that produced this update
+    values: dict[str, Any]  # State delta
+
+class CustomData(TypedDict):
+    name: NotRequired[str]  # Custom event name for dispatch
+    payload: Any  # User-defined payload
+

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -7,7 +7,7 @@ name = "langchain-protocol"
 description = "Python bindings for the LangChain agent streaming protocol"
 license = { text = "MIT" }
 readme = "README.md"
-version = "0.0.12"
+version = "0.0.13"
 requires-python = ">=3.10.0,<4.0.0"
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langchain-protocol"
+description = "Python bindings for the LangChain agent streaming protocol"
+license = { text = "MIT" }
+readme = "README.md"
+version = "0.0.12"
+requires-python = ">=3.10.0,<4.0.0"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = ["typing-extensions>=4.7.0,<5.0.0"]

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -23,3 +23,8 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = ["typing-extensions>=4.7.0,<5.0.0"]
+
+[project.urls]
+Homepage = "https://github.com/langchain-ai/agent-protocol/tree/main/streaming"
+Repository = "https://github.com/langchain-ai/agent-protocol"
+Issues = "https://github.com/langchain-ai/agent-protocol/issues"

--- a/streaming/scripts/fixup.py
+++ b/streaming/scripts/fixup.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Fixup generated Python protocol bindings.
+
+cddl2py emits definitions in CDDL schema order, which may not satisfy Python's
+eager-evaluation constraints.  This script topologically sorts top-level
+statements so that every name is defined before its first runtime use.
+
+With ``from __future__ import annotations``, type annotations are lazy strings
+and create no runtime dependency.  Only class base classes, class keyword
+arguments, and assignment right-hand sides are eagerly evaluated.
+
+It also patches a known cddl2py bug: the string literal ``"text"`` collides
+with the CDDL primitive ``text`` and emits as the bare type ``str`` rather
+than ``Literal["text"]`` on ``TextContentBlock.type``.
+
+Usage::
+
+    cddl2py protocol.cddl | python3 scripts/fixup.py > out.py
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+
+
+def _names_in(node: ast.AST) -> set[str]:
+    """Collect all ``ast.Name.id`` references in *node*'s subtree."""
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+
+
+def _runtime_deps(node: ast.stmt) -> set[str]:
+    """Return names that must be defined before *node* can execute."""
+    deps: set[str] = set()
+    if isinstance(node, ast.ClassDef):
+        for base in node.bases:
+            deps |= _names_in(base)
+        for kw in node.keywords:
+            deps |= _names_in(kw.value)
+    elif isinstance(node, ast.Assign):
+        deps |= _names_in(node.value)
+    return deps
+
+
+def _defined_names(node: ast.stmt) -> set[str]:
+    """Return the names that *node* introduces into the module scope."""
+    if isinstance(node, ast.ClassDef):
+        return {node.name}
+    if isinstance(node, ast.Assign):
+        return {t.id for t in node.targets if isinstance(t, ast.Name)}
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return {(a.asname or a.name) for a in node.names}
+    return set()
+
+
+_TEXT_TYPE_BUG_RE = re.compile(
+    r"(class TextContentBlock\(TypedDict\):\n)    type: str\n",
+)
+
+
+def _patch_text_content_block_type(source: str) -> str:
+    """Replace ``type: str`` on ``TextContentBlock`` with ``Literal["text"]``.
+
+    Works around a cddl2py bug where the string literal ``"text"`` is resolved
+    as the CDDL primitive ``text`` (i.e. ``str``) instead of a literal.
+    """
+    new_source, count = _TEXT_TYPE_BUG_RE.subn(
+        r'\1    type: Literal["text"]\n', source
+    )
+    if count != 1:
+        msg = (
+            "fixup: expected exactly one TextContentBlock.type=str occurrence "
+            f"to patch, found {count}. Upstream cddl2py output has changed."
+        )
+        raise RuntimeError(msg)
+    return new_source
+
+
+def fixup(source: str) -> str:
+    source = _patch_text_content_block_type(source)
+    tree = ast.parse(source)
+    source_lines = source.splitlines(keepends=True)
+
+    if not tree.body:
+        return source
+
+    # Collect all names defined in the file (for filtering external deps).
+    all_defined: set[str] = set()
+    for node in tree.body:
+        all_defined |= _defined_names(node)
+
+    # Split AST nodes into blocks, each carrying its source text.
+    # A block's text spans from its first line to the line before the next node.
+    preamble_end = tree.body[0].lineno - 1  # 0-indexed, exclusive
+    preamble = "".join(source_lines[:preamble_end])
+
+    blocks: list[dict] = []
+    for i, node in enumerate(tree.body):
+        start = node.lineno - 1
+        end = (
+            tree.body[i + 1].lineno - 1
+            if i + 1 < len(tree.body)
+            else len(source_lines)
+        )
+        blocks.append(
+            {
+                "idx": i,
+                "text": "".join(source_lines[start:end]),
+                "defined": _defined_names(node),
+                "deps": _runtime_deps(node) & all_defined,
+                "is_import": isinstance(node, (ast.Import, ast.ImportFrom)),
+            }
+        )
+
+    # Keep imports at the top in their original order.
+    header = [b for b in blocks if b["is_import"]]
+    body = [b for b in blocks if not b["is_import"]]
+
+    # Greedy topological sort that preserves original order where possible.
+    defined_so_far: set[str] = set()
+    for b in header:
+        defined_so_far |= b["defined"]
+
+    sorted_body: list[dict] = []
+    remaining = list(body)
+
+    while remaining:
+        ready = [b for b in remaining if b["deps"] <= defined_so_far]
+        if not ready:
+            # Cycle or unresolvable — emit the rest in original order.
+            sorted_body.extend(sorted(remaining, key=lambda b: b["idx"]))
+            break
+        pick = min(ready, key=lambda b: b["idx"])
+        sorted_body.append(pick)
+        defined_so_far |= pick["defined"]
+        remaining.remove(pick)
+
+    return (
+        preamble
+        + "".join(b["text"] for b in header)
+        + "".join(b["text"] for b in sorted_body)
+    )
+
+
+if __name__ == "__main__":
+    sys.stdout.write(fixup(sys.stdin.read()))


### PR DESCRIPTION
## Summary

- Adds the Agent Streaming Protocol artifacts under `streaming/`.
- Migrates the CDDL schema plus generated TypeScript and Python bindings into the Agent Protocol repo.
- Adds comprehensive documentation for streaming primitives, including transports, framing, channels, namespaces, state/checkpoints, replay, and generated bindings.
