### PR TITLE
feat(core): add optional 'name' field to Message schema

### DIFF
--- a/client-python/ap_client/models/message.py
+++ b/client-python/ap_client/models/message.py
@@ -31,11 +31,14 @@ class Message(BaseModel):
     role: StrictStr = Field(description="The role of the message.")
     content: Content
     id: Optional[StrictStr] = Field(default=None, description="The ID of the message.")
+    name: Optional[StrictStr] = Field(
+        default=None, description="The name of the message author or tool."
+    )
     metadata: Optional[Dict[str, Any]] = Field(
         default=None, description="The metadata of the message."
     )
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["role", "content", "id", "metadata"]
+    __properties: ClassVar[List[str]] = ["role", "content", "id", "name", "metadata"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -105,6 +108,7 @@ class Message(BaseModel):
                 if obj.get("content") is not None
                 else None,
                 "id": obj.get("id"),
+                "name": obj.get("name"),
                 "metadata": obj.get("metadata"),
             }
         )

--- a/openapi.json
+++ b/openapi.json
@@ -2058,6 +2058,11 @@
             "title": "Id",
             "description": "The ID of the message."
           },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the message author or tool."
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": true,

--- a/server/ap_server/models.py
+++ b/server/ap_server/models.py
@@ -284,6 +284,9 @@ class Message(BaseModel):
         ..., description="The content of the message.", title="Content"
     )
     id: Optional[str] = Field(None, description="The ID of the message.", title="Id")
+    name: Optional[str] = Field(
+        None, description="The name of the message author or tool.", title="Name"
+    )
     metadata: Optional[Dict[str, Any]] = Field(
         None, description="The metadata of the message.", title="Metadata"
     )


### PR DESCRIPTION
Fixes #73

This PR adds an optional `name` field to the `Message` schema across `openapi.json`, the server Python models, and the client Python models to support naming for tool calls and message authors.
