### PR TITLE
chore: update chat model delta

### DIFF
--- a/streaming/README.md
+++ b/streaming/README.md
@@ -25,9 +25,10 @@ The protocol is built around a few stable primitives:
   to the data they need.
 - Namespaces identify positions in an agent or graph tree, allowing clients to
   subscribe to a root agent, a subgraph, or a bounded depth below either.
-- Content blocks are the universal carrier for model output deltas, including
-  text, reasoning, tool calls, server-side tool calls, multimodal data, and
-  provider-specific extensions.
+- Content blocks are the universal carrier for model output, including text,
+  reasoning, tool calls, server-side tool calls, multimodal data, and
+  provider-specific extensions. Content block deltas use explicit append/merge
+  semantics.
 - Events carry explicit lifecycle boundaries. Clients do not need to infer when
   a message, content block, tool call, run, or subgraph starts and finishes.
 - Replay is sequence-based, allowing clients to reconnect and request missed
@@ -204,16 +205,32 @@ Content blocks do not interleave within a single message. Block `N` finishes
 before block `N + 1` starts. This matches common LLM provider streaming behavior
 and keeps client assembly deterministic.
 
-Delta events carry the same content block union as finalized content. The
-block's `type` field is the discriminant. For example:
+Delta events carry explicit delta variants. `text-delta` appends to the active
+block's `text` field, `reasoning-delta` appends to `reasoning`, `data-delta`
+appends encoded data chunks to `base64`, and `block-delta` shallow-merges
+fields onto the active block. For example:
 
 ```json
 {
   "event": "content-block-delta",
   "index": 0,
-  "content": {
-    "type": "text",
+  "delta": {
+    "type": "text-delta",
     "text": "Hello "
+  }
+}
+```
+
+Multimodal data streams use `data-delta` for encoded chunks:
+
+```json
+{
+  "event": "content-block-delta",
+  "index": 1,
+  "delta": {
+    "type": "data-delta",
+    "data": "UklGR...",
+    "encoding": "base64"
   }
 }
 ```
@@ -224,11 +241,14 @@ Tool call arguments stream as chunk content and finalize as parsed tool calls:
 {
   "event": "content-block-delta",
   "index": 1,
-  "content": {
-    "type": "tool_call_chunk",
-    "id": "call_123",
-    "name": "search",
-    "args": "{\"query\":"
+  "delta": {
+    "type": "block-delta",
+    "fields": {
+      "type": "tool_call_chunk",
+      "id": "call_123",
+      "name": "search",
+      "args": "{\"query\":"
+    }
   }
 }
 ```
@@ -386,8 +406,10 @@ for forward compatibility. Consumers should ignore unknown fields and default
 unknown tagged variants to a safe fallback instead of failing closed.
 
 Content blocks are especially extensible. New block types can be added to
-LangChain content block definitions and flow through the same message lifecycle
-without changing the transport or channel model.
+LangChain content block definitions and flow through the same message lifecycle.
+During streaming, encoded data chunks can use `data-delta`, while block-specific
+incremental fields can use `block-delta` without changing the transport or
+channel model.
 
 ## Generated Bindings
 

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -11,7 +11,8 @@
 // event filtering, hierarchical namespace scoping, and multi-transport
 // support (WebSocket, SSE, in-process).
 // The result is a single protocol where:
-// - Content blocks are the universal delta carrier for LLM streaming
+// - Content blocks are the universal carrier for LLM output
+// - Content block deltas have explicit append/merge semantics
 // - Events have full lifecycle semantics (no inferred boundaries)
 // - Namespace-based filtering provides server-side routing
 // - Threads are the primary routing key across all transports
@@ -48,10 +49,10 @@ export type MessageRole = "ai" | "human" | "system";
 
 // ==========================================================================
 // 2. Content Block Types
-// LangChain content blocks are the universal carrier for streaming
-// deltas. The block's `type` field is the discriminant. New content
-// block types automatically work with the streaming protocol without
-// protocol changes.
+// LangChain content blocks are the universal carrier for model output.
+// The block's `type` field is the discriminant. New content block
+// types automatically work with the streaming protocol without protocol
+// changes by using BlockDelta for incremental field updates.
 // "Chunk" variants (ToolCallChunk, ServerToolCallChunk) carry
 // partial/incremental data during streaming. "Standard" variants carry
 // finalized data. ContentBlockFinish events upgrade chunks to their
@@ -221,6 +222,55 @@ export type FileContentBlock = Extensible & {
   index?: BlockIndex;
 };
 
+// Explicit incremental updates for content blocks.
+// TextDelta, ReasoningDelta, and DataDelta append to their named fields.
+// BlockDelta shallow-merges `fields` onto the accumulated content block.
+// Producers should use DataDelta for streamed base64 chunks in image,
+// audio, video, or file blocks. Use BlockDelta for tool-call argument
+// streaming, provider signatures, citations, compaction markers, and
+// future block fields without dedicated append semantics.
+export type NonStandardContentBlock = Extensible & {
+  type: "non_standard";
+  value: Record<string, any>;
+  id?: string;
+  index?: BlockIndex;
+};
+
+export type TextDelta = Extensible & {
+  type: "text-delta";
+  text: string;
+};
+
+export type ReasoningDelta = Extensible & {
+  type: "reasoning-delta";
+  reasoning: string;
+};
+
+// One-layer patch for the currently active content block.
+// `type` identifies the content block type whose fields are being
+// updated; all other keys are shallow-merged onto the accumulated block.
+export type DataDelta = Extensible & {
+  type: "data-delta";
+  /**
+   * Encoded data chunk to append
+   */
+  data: string;
+  /**
+   * Defaults to base64 when absent
+   */
+  encoding?: "base64";
+};
+
+export interface BlockDeltaFields {
+  type: string;
+  [key: string]: any | undefined;
+}
+
+export type BlockDelta = Extensible & {
+  type: "block-delta";
+  fields: BlockDeltaFields;
+};
+
 // ==========================================================================
 // 3. Top-Level Message Framing
 // Three message types flow over the connection:
@@ -230,12 +280,7 @@ export type FileContentBlock = Extensible & {
 // Event           — server -> client (unsolicited push)
 // ==========================================================================
 // --- Client -> Server ---
-export type NonStandardContentBlock = Extensible & {
-  type: "non_standard";
-  value: Record<string, any>;
-  id?: string;
-  index?: BlockIndex;
-};
+export type ContentBlockDelta = TextDelta | ReasoningDelta | DataDelta | BlockDelta;
 
 export type Command = CommandData & Extensible & {
   id: JsUint;
@@ -617,19 +662,21 @@ export interface LifecycleCauseEdge {
 // as complete messages. Events follow a strict lifecycle:
 // message-start
 // -> content-block-start(index=0, contentBlock)
-// -> content-block-delta(index=0, contentBlock) ...
+// -> content-block-delta(index=0, delta) ...
 // -> content-block-finish(index=0, contentBlock)
 // -> content-block-start(index=1, contentBlock)
-// -> content-block-delta(index=1, contentBlock) ...
+// -> content-block-delta(index=1, delta) ...
 // -> content-block-finish(index=1, contentBlock)
 // -> message-finish(reason)
 // Content blocks MUST NOT interleave: block N must finish before block
 // N+1 starts. This constraint applies within a single message
 // (identified by namespace + node) and matches observed behavior of
 // all major LLM providers.
-// Delta events carry LangChain ContentBlock instances directly —
-// the block's `type` field is the discriminant. This means adding
-// a new content block type to LangChain requires zero protocol changes.
+// Delta events carry explicit delta variants:
+// - text-delta appends to the active block's `text` field
+// - reasoning-delta appends to the active block's `reasoning` field
+// - data-delta appends to the active block's `base64` field
+// - block-delta shallow-merges `fields` onto the active block
 // ==========================================================================
 export interface LifecycleData {
   event: AgentStatus;
@@ -680,11 +727,12 @@ export type MessageStartData = Extensible & {
   metadata?: MessageMetadata;
 };
 
-// Emitted for each incremental update within a content block. The
-// contentBlock carries only the delta for this update:
-// { type: "text", text: "Hello " }           — text delta
-// { type: "reasoning", reasoning: "Let me" } — reasoning delta
-// { type: "tool_call_chunk", args: '{"q":' } — tool call args delta
+// Emitted for each incremental update within a content block:
+// { type: "text-delta", text: "Hello " }                 — append text
+// { type: "reasoning-delta", reasoning: "Let me" }       — append reasoning
+// { type: "data-delta", data: "UklGR..." }               — append base64 data
+// { type: "block-delta", fields: { type: "tool_call_chunk", args: '{"q":' } }
+// — shallow merge fields
 export type ContentBlockStartData = Extensible & {
   event: "content-block-start";
   /**
@@ -700,7 +748,7 @@ export type ContentBlockStartData = Extensible & {
 export type ContentBlockDeltaData = Extensible & {
   event: "content-block-delta";
   index: number;
-  content: ContentBlock;
+  delta: ContentBlockDelta;
 };
 
 // Emitted once when the message is complete.

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -16,7 +16,8 @@
 ;      support (WebSocket, SSE, in-process).
 ;
 ; The result is a single protocol where:
-;   - Content blocks are the universal delta carrier for LLM streaming
+;   - Content blocks are the universal carrier for LLM output
+;   - Content block deltas have explicit append/merge semantics
 ;   - Events have full lifecycle semantics (no inferred boundaries)
 ;   - Namespace-based filtering provides server-side routing
 ;   - Threads are the primary routing key across all transports
@@ -69,10 +70,10 @@ MessageMetadata = {
 ; ==========================================================================
 ; 2. Content Block Types
 ;
-; LangChain content blocks are the universal carrier for streaming
-; deltas. The block's `type` field is the discriminant. New content
-; block types automatically work with the streaming protocol without
-; protocol changes.
+; LangChain content blocks are the universal carrier for model output.
+; The block's `type` field is the discriminant. New content block
+; types automatically work with the streaming protocol without protocol
+; changes by using BlockDelta for incremental field updates.
 ;
 ; "Chunk" variants (ToolCallChunk, ServerToolCallChunk) carry
 ; partial/incremental data during streaming. "Standard" variants carry
@@ -258,6 +259,52 @@ NonStandardContentBlock = {
   ? index: BlockIndex,
   Extensible,
 }
+
+; Explicit incremental updates for content blocks.
+;
+; TextDelta, ReasoningDelta, and DataDelta append to their named fields.
+; BlockDelta shallow-merges `fields` onto the accumulated content block.
+; Producers should use DataDelta for streamed base64 chunks in image,
+; audio, video, or file blocks. Use BlockDelta for tool-call argument
+; streaming, provider signatures, citations, compaction markers, and
+; future block fields without dedicated append semantics.
+TextDelta = {
+  type: "text-delta",
+  text: text,
+  Extensible,
+}
+
+ReasoningDelta = {
+  type: "reasoning-delta",
+  reasoning: text,
+  Extensible,
+}
+
+DataDelta = {
+  type: "data-delta",
+  data: text,                              ; Encoded data chunk to append
+  ? encoding: "base64",                   ; Defaults to base64 when absent
+  Extensible,
+}
+
+; One-layer patch for the currently active content block.
+; `type` identifies the content block type whose fields are being
+; updated; all other keys are shallow-merged onto the accumulated block.
+BlockDeltaFields = {
+  type: text,
+  * text => any,
+}
+
+BlockDelta = {
+  type: "block-delta",
+  fields: BlockDeltaFields,
+  Extensible,
+}
+
+ContentBlockDelta = TextDelta
+                  / ReasoningDelta
+                  / DataDelta
+                  / BlockDelta
 
 
 ; ==========================================================================
@@ -726,10 +773,10 @@ LifecycleData = {
 ;
 ;   message-start
 ;     -> content-block-start(index=0, contentBlock)
-;       -> content-block-delta(index=0, contentBlock) ...
+;       -> content-block-delta(index=0, delta) ...
 ;     -> content-block-finish(index=0, contentBlock)
 ;     -> content-block-start(index=1, contentBlock)
-;       -> content-block-delta(index=1, contentBlock) ...
+;       -> content-block-delta(index=1, delta) ...
 ;     -> content-block-finish(index=1, contentBlock)
 ;   -> message-finish(reason)
 ;
@@ -738,9 +785,11 @@ LifecycleData = {
 ; (identified by namespace + node) and matches observed behavior of
 ; all major LLM providers.
 ;
-; Delta events carry LangChain ContentBlock instances directly —
-; the block's `type` field is the discriminant. This means adding
-; a new content block type to LangChain requires zero protocol changes.
+; Delta events carry explicit delta variants:
+;   - text-delta appends to the active block's `text` field
+;   - reasoning-delta appends to the active block's `reasoning` field
+;   - data-delta appends to the active block's `base64` field
+;   - block-delta shallow-merges `fields` onto the active block
 ; ==========================================================================
 
 MessagesEvent = {
@@ -779,15 +828,16 @@ ContentBlockStartData = {
   Extensible,
 }
 
-; Emitted for each incremental update within a content block. The
-; contentBlock carries only the delta for this update:
-;   { type: "text", text: "Hello " }           — text delta
-;   { type: "reasoning", reasoning: "Let me" } — reasoning delta
-;   { type: "tool_call_chunk", args: '{"q":' } — tool call args delta
+; Emitted for each incremental update within a content block:
+;   { type: "text-delta", text: "Hello " }                 — append text
+;   { type: "reasoning-delta", reasoning: "Let me" }       — append reasoning
+;   { type: "data-delta", data: "UklGR..." }               — append base64 data
+;   { type: "block-delta", fields: { type: "tool_call_chunk", args: '{"q":' } }
+;                                                            — shallow merge fields
 ContentBlockDeltaData = {
   event: "content-block-delta",
   index: uint,
-  content: ContentBlock,
+  delta: ContentBlockDelta,
   Extensible,
 }
 

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -153,6 +153,28 @@ class NonStandardAnnotation(TypedDict):
 
 Annotation = Union[Citation, NonStandardAnnotation]
 
+class TextDelta(TypedDict):
+    type: Literal["text-delta"]
+    text: str
+
+class ReasoningDelta(TypedDict):
+    type: Literal["reasoning-delta"]
+    reasoning: str
+
+class DataDelta(TypedDict):
+    type: Literal["data-delta"]
+    data: str  # Encoded data chunk to append
+    encoding: NotRequired[Literal["base64"]]  # Defaults to base64 when absent
+
+class BlockDeltaFields(TypedDict, extra_items=Any):
+    type: str
+
+class BlockDelta(TypedDict):
+    type: Literal["block-delta"]
+    fields: BlockDeltaFields
+
+ContentBlockDelta = Union[TextDelta, ReasoningDelta, DataDelta, BlockDelta]
+
 class RunInput(TypedDict):
     method: Literal["run.input"]
     params: RunInputParams
@@ -442,7 +464,7 @@ class ContentBlockStartData(TypedDict):
 class ContentBlockDeltaData(TypedDict):
     event: Literal["content-block-delta"]
     index: int
-    content: ContentBlock
+    delta: ContentBlockDelta
 
 class ContentBlockFinishData(TypedDict):
     event: Literal["content-block-finish"]

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -7,7 +7,7 @@ name = "langchain-protocol"
 description = "Python bindings for the LangChain agent streaming protocol"
 license = { text = "MIT" }
 readme = "README.md"
-version = "0.0.13"
+version = "0.0.14"
 requires-python = ">=3.10.0,<4.0.0"
 classifiers = [
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary

This updates the streaming protocol’s `content-block-delta` shape to make delta merge semantics explicit.

Instead of carrying a partial content block in `content`, delta events now carry a `delta` union:

- `text-delta`: append to the active block’s `text` field
- `reasoning-delta`: append to the active block’s `reasoning` field
- `data-delta`: append encoded data chunks to the active multimodal block’s `base64` field
- `block-delta`: shallow-merge fields onto the active block

The generated TypeScript and Python bindings were regenerated from the updated CDDL, and the README examples were updated to match the new protocol shape.

## Motivation

Using content-block-shaped deltas made the merge behavior implicit. For example, text and reasoning fields append, while most other fields merge or overwrite. This change makes those behaviors part of the protocol surface so consumers can switch on the delta type and apply the correct merge rule directly.

`data-delta` keeps multimodal streaming support explicit as well, covering existing demos that stream audio as base64 chunks without overloading generic `block-delta` merge semantics.
