### PR TITLE
fix: run.input < run.start

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1213,7 +1213,7 @@
       "post": {
         "tags": ["Streaming"],
         "summary": "Send Thread Streaming Command",
-        "description": "Send a streaming protocol command to a thread over HTTP. This endpoint is the request/response companion to the SSE event stream and supports commands such as `run.input`, `input.respond`, `input.inject`, `state.get`, `state.listCheckpoints`, and `state.fork`.",
+        "description": "Send a streaming protocol command to a thread over HTTP. This endpoint is the request/response companion to the SSE event stream and supports commands such as `run.start`, `input.respond`, `input.inject`, `state.get`, `state.listCheckpoints`, and `state.fork`.",
         "operationId": "send_thread_streaming_command",
         "parameters": [
           {
@@ -1649,7 +1649,7 @@
           },
           "method": {
             "type": "string",
-            "description": "Streaming protocol command method, such as `run.input`, `subscription.subscribe`, `input.respond`, or `state.get`."
+            "description": "Streaming protocol command method, such as `run.start`, `subscription.subscribe`, `input.respond`, or `state.get`."
           },
           "params": {
             "type": "object",

--- a/streaming/README.md
+++ b/streaming/README.md
@@ -87,7 +87,7 @@ Client-to-server messages are commands:
 ```json
 {
   "id": 1,
-  "method": "run.input",
+  "method": "run.start",
   "params": {
     "assistantId": "agent",
     "input": {
@@ -154,10 +154,10 @@ ordering and replay.
 
 The protocol is thread-centric. A thread is the durable identity for state,
 checkpoints, run history, and stream routing. A server may create a thread
-lazily when it receives the first `run.input` command for a thread that does not
+lazily when it receives the first `run.start` command for a thread that does not
 exist yet.
 
-`run.input` is the main entry point for execution input:
+`run.start` is the main entry point for execution input:
 
 - If no run is active, it starts a new run.
 - If the run is interrupted, it resumes the run with the provided value.

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -330,7 +330,7 @@ export type ErrorCode = "invalid_argument" | "unknown_command" | "unknown_error"
 // for commands, events, and subscriptions. There is no session handshake
 // or server-side session state.
 // Thread IDs may be client-generated (UUID) or server-assigned. The
-// server creates the thread lazily on the first `run.input` if it does
+// server creates the thread lazily on the first `run.start` if it does
 // not already exist.
 // Transport endpoints:
 // **SSE/HTTP:**
@@ -344,7 +344,7 @@ export type ErrorCode = "invalid_argument" | "unknown_command" | "unknown_error"
 // depth) and the server streams matching events for the lifetime of that
 // connection. Closing the connection unsubscribes. No subscription state
 // is persisted on the server. Event streams can be opened before or after
-// `run.input`; streams opened before a run exists stay idle until events
+// `run.start`; streams opened before a run exists stay idle until events
 // are produced.
 // **WebSocket:** Subscriptions are managed via in-band
 // `subscription.subscribe` and `subscription.unsubscribe` commands on
@@ -361,7 +361,7 @@ export type ErrorCode = "invalid_argument" | "unknown_command" | "unknown_error"
 // ==========================================================================
 // ==========================================================================
 // 4a. Run Module
-// `run.input` is the single entry point for all input to the graph.
+// `run.start` is the single entry point for all input to the graph.
 // The thread manages a state machine:
 // - No active run  → starts a new run with the provided input
 // - Run interrupted → resumes with the input as the resume value
@@ -373,14 +373,14 @@ export type ResponseMeta = Extensible & {
   applied_through_seq?: JsUint;
 };
 
-export type RunCommand = RunInput;
+export type RunCommand = RunStart;
 
-export interface RunInput {
-  method: "run.input";
-  params: RunInputParams;
+export interface RunStart {
+  method: "run.start";
+  params: RunStartParams;
 }
 
-export interface RunInputParams {
+export interface RunStartParams {
   /**
    * Deployed graph/agent to run
    */

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -405,7 +405,7 @@ ResponseMeta = {
 ; or server-side session state.
 ;
 ; Thread IDs may be client-generated (UUID) or server-assigned. The
-; server creates the thread lazily on the first `run.input` if it does
+; server creates the thread lazily on the first `run.start` if it does
 ; not already exist.
 ;
 ; Transport endpoints:
@@ -424,7 +424,7 @@ ResponseMeta = {
 ; depth) and the server streams matching events for the lifetime of that
 ; connection. Closing the connection unsubscribes. No subscription state
 ; is persisted on the server. Event streams can be opened before or after
-; `run.input`; streams opened before a run exists stay idle until events
+; `run.start`; streams opened before a run exists stay idle until events
 ; are produced.
 ;
 ; **WebSocket:** Subscriptions are managed via in-band
@@ -447,7 +447,7 @@ ResponseMeta = {
 ; ==========================================================================
 ; 4a. Run Module
 ;
-; `run.input` is the single entry point for all input to the graph.
+; `run.start` is the single entry point for all input to the graph.
 ; The thread manages a state machine:
 ;
 ;   - No active run  → starts a new run with the provided input
@@ -458,14 +458,14 @@ ResponseMeta = {
 ; run on this thread. It replaces session-level target binding.
 ; ==========================================================================
 
-RunCommand = run.input
+RunCommand = run.start
 
-run.input = {
-  method: "run.input",
-  params: RunInputParams,
+run.start = {
+  method: "run.start",
+  params: RunStartParams,
 }
 
-RunInputParams = {
+RunStartParams = {
   assistantId: text,                     ; Deployed graph/agent to run
   input: any,                            ; Graph input, resume value, or injected message
   ? config: {* text => any},             ; Per-run config overrides

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -175,9 +175,9 @@ class BlockDelta(TypedDict):
 
 ContentBlockDelta = Union[TextDelta, ReasoningDelta, DataDelta, BlockDelta]
 
-class RunInput(TypedDict):
-    method: Literal["run.input"]
-    params: RunInputParams
+class RunStart(TypedDict):
+    method: Literal["run.start"]
+    params: RunStartParams
 
 class SubscriptionSubscribe(TypedDict):
     method: Literal["subscription.subscribe"]
@@ -370,12 +370,12 @@ ErrorCode = Union[Literal["invalid_argument"], Literal["unknown_command"], Liter
 class ResponseMeta(TypedDict):
     applied_through_seq: NotRequired[JsUint]
 
-RunCommand = RunInput
+RunCommand = RunStart
 
 class _CommandVariant0(_CommandFields, RunCommand):
     pass
 
-class RunInputParams(TypedDict):
+class RunStartParams(TypedDict):
     assistant_id: str  # Deployed graph/agent to run
     input: Any  # Graph input, resume value, or injected message
     config: NotRequired[dict[str, Any]]  # Per-run config overrides


### PR DESCRIPTION
Renaming `run.input` into `run.start`.