### PR TITLE
chore: bump `typing-extensions` floor from `>=4.7.0` to `>=4.13.0`

### DIFF
--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["typing-extensions>=4.7.0,<5.0.0"]
+dependencies = ["typing-extensions>=4.13.0,<5.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/langchain-ai/agent-protocol/tree/main/streaming"


### PR DESCRIPTION
`protocol.py:22` uses PEP 728 `class MessageMetadata(TypedDict, extra_items=MetadataScalar)`, which requires `typing-extensions >= 4.13.0` on Python < 3.13. The previous floor allowed resolvers to pick 4.12.x, producing resolution errors