### PR TITLE
feat(protocol): add batch resume for parallel interrupts

### DIFF
--- a/streaming/js/package.json
+++ b/streaming/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/protocol",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "TypeScript bindings for the LangChain agent streaming protocol",
   "license": "MIT",
   "keywords": [

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -845,13 +845,49 @@ export type ToolErrorData = Extensible & {
 // --- input.respond ---
 export type InputCommand = InputRespond | InputInject;
 
+// A respond command resolves either a single interrupt or several
+// interrupts that are pending at the same checkpoint (e.g. parallel
+// tool-authorization prompts). The batch form is required because
+// sequential single resumes cannot do this: the first resume starts a
+// run, leaving the remaining interrupts with no interrupted run to
+// respond to.
 export interface InputRespond {
   method: "input.respond";
   params: InputRespondParams;
 }
 
+// Single-interrupt resume.
+export type InputRespondParams = InputRespondOne | InputRespondMany;
+
+// Batch resume — one entry per interrupt, resumed in a single run.
+export interface InputRespondOne {
+  namespace: Namespace;
+  interrupt_id: string;
+  response: any;
+  /**
+   * Per-run config overrides
+   */
+  config?: Record<string, any>;
+  /**
+   * Per-run metadata
+   */
+  metadata?: Record<string, any>;
+}
+
+export interface InputRespondMany {
+  responses: InputRespondEntry[];
+  /**
+   * Per-run config overrides
+   */
+  config?: Record<string, any>;
+  /**
+   * Per-run metadata
+   */
+  metadata?: Record<string, any>;
+}
+
 // --- input.inject ---
-export interface InputRespondParams {
+export interface InputRespondEntry {
   namespace: Namespace;
   interrupt_id: string;
   response: any;

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -956,7 +956,31 @@ input.respond = {
   params: InputRespondParams,
 }
 
-InputRespondParams = {
+; A respond command resolves either a single interrupt or several
+; interrupts that are pending at the same checkpoint (e.g. parallel
+; tool-authorization prompts). The batch form is required because
+; sequential single resumes cannot do this: the first resume starts a
+; run, leaving the remaining interrupts with no interrupted run to
+; respond to.
+InputRespondParams = InputRespondOne / InputRespondMany
+
+; Single-interrupt resume.
+InputRespondOne = {
+  namespace: Namespace,
+  interruptId: text,
+  response: any,
+  ? config: {* text => any},             ; Per-run config overrides
+  ? metadata: {* text => any},           ; Per-run metadata
+}
+
+; Batch resume — one entry per interrupt, resumed in a single run.
+InputRespondMany = {
+  responses: [+ InputRespondEntry],
+  ? config: {* text => any},             ; Per-run config overrides
+  ? metadata: {* text => any},           ; Per-run metadata
+}
+
+InputRespondEntry = {
   namespace: Namespace,
   interruptId: text,
   response: any,

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -511,7 +511,21 @@ class ToolErrorData(TypedDict):
 
 ToolsData = Union[ToolStartedData, ToolOutputDeltaData, ToolFinishedData, ToolErrorData]
 
-class InputRespondParams(TypedDict):
+class InputRespondOne(TypedDict):
+    namespace: Namespace
+    interrupt_id: str
+    response: Any
+    config: NotRequired[dict[str, Any]]  # Per-run config overrides
+    metadata: NotRequired[dict[str, Any]]  # Per-run metadata
+
+class InputRespondMany(TypedDict):
+    responses: list[InputRespondEntry]
+    config: NotRequired[dict[str, Any]]  # Per-run config overrides
+    metadata: NotRequired[dict[str, Any]]  # Per-run metadata
+
+InputRespondParams = Union[InputRespondOne, InputRespondMany]
+
+class InputRespondEntry(TypedDict):
     namespace: Namespace
     interrupt_id: str
     response: Any

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -7,7 +7,7 @@ name = "langchain-protocol"
 description = "Python bindings for the LangChain agent streaming protocol"
 license = { text = "MIT" }
 readme = "README.md"
-version = "0.0.15"
+version = "0.0.16"
 requires-python = ">=3.10.0,<4.0.0"
 classifiers = [
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary
- Add `InputRespondOne` interface for single-interrupt resume
- Add `InputRespondMany` interface for batch resume of multiple interrupts
- Rename existing params type to `InputRespondEntry` for clarity
- Update CDDL spec, TypeScript types, and Python bindings

This enables clients to respond to multiple parallel interrupts (e.g., simultaneous tool authorization prompts) in a single run rather than requiring sequential responses that would fail for subsequent interrupts.
