### PR TITLE
feat: add token-detail breakdowns to UsageInfo

### DIFF
--- a/streaming/js/package.json
+++ b/streaming/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/protocol",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "TypeScript bindings for the LangChain agent streaming protocol",
   "license": "MIT",
   "keywords": [

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -758,6 +758,8 @@ export type ContentBlockFinishData = Extensible & {
   content: FinalizedContentBlock;
 };
 
+// Breakdown of input token counts. Keys are optional and need not sum to
+// inputTokens; may also hold extra provider-specific keys.
 export type MessageFinishData = Extensible & {
   event: "message-finish";
   /**
@@ -766,11 +768,26 @@ export type MessageFinishData = Extensible & {
   usage?: UsageInfo;
 };
 
+// Breakdown of output token counts. Keys are optional and need not sum to
+// outputTokens; may also hold extra provider-specific keys.
+export type InputTokenDetails = Extensible & {
+  audio?: number;
+  cache_creation?: number;
+  cache_read?: number;
+};
+
+export type OutputTokenDetails = Extensible & {
+  audio?: number;
+  reasoning?: number;
+};
+
 // Emitted on unrecoverable errors within a model call.
 export type UsageInfo = Extensible & {
   input_tokens?: number;
   output_tokens?: number;
   total_tokens?: number;
+  input_token_details?: InputTokenDetails;
+  output_token_details?: OutputTokenDetails;
 };
 
 // ==========================================================================

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -858,10 +858,29 @@ MessageFinishData = {
   Extensible,
 }
 
+; Breakdown of input token counts. Keys are optional and need not sum to
+; inputTokens; may also hold extra provider-specific keys.
+InputTokenDetails = {
+  ? audio: uint,
+  ? cacheCreation: uint,
+  ? cacheRead: uint,
+  Extensible,
+}
+
+; Breakdown of output token counts. Keys are optional and need not sum to
+; outputTokens; may also hold extra provider-specific keys.
+OutputTokenDetails = {
+  ? audio: uint,
+  ? reasoning: uint,
+  Extensible,
+}
+
 UsageInfo = {
   ? inputTokens: uint,
   ? outputTokens: uint,
   ? totalTokens: uint,
+  ? inputTokenDetails: InputTokenDetails,
+  ? outputTokenDetails: OutputTokenDetails,
   Extensible,
 }
 

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -482,10 +482,21 @@ class MessageErrorData(TypedDict):
 
 MessagesData = Union[MessageStartData, ContentBlockStartData, ContentBlockDeltaData, ContentBlockFinishData, MessageFinishData, MessageErrorData]
 
+class InputTokenDetails(TypedDict):
+    audio: NotRequired[int]
+    cache_creation: NotRequired[int]
+    cache_read: NotRequired[int]
+
+class OutputTokenDetails(TypedDict):
+    audio: NotRequired[int]
+    reasoning: NotRequired[int]
+
 class UsageInfo(TypedDict):
     input_tokens: NotRequired[int]
     output_tokens: NotRequired[int]
     total_tokens: NotRequired[int]
+    input_token_details: NotRequired[InputTokenDetails]
+    output_token_details: NotRequired[OutputTokenDetails]
 
 class ToolStartedData(TypedDict):
     event: Literal["tool-started"]

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -7,7 +7,7 @@ name = "langchain-protocol"
 description = "Python bindings for the LangChain agent streaming protocol"
 license = { text = "MIT" }
 readme = "README.md"
-version = "0.0.16"
+version = "0.0.17"
 requires-python = ">=3.10.0,<4.0.0"
 classifiers = [
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Adds optional `inputTokenDetails` / `outputTokenDetails` to the protocol `UsageInfo` type, backed by two new groups `InputTokenDetails` (`audio`, `cacheCreation`, `cacheRead`) and `OutputTokenDetails` (`audio`, `reasoning`). All fields are optional and the groups stay `Extensible`, so this is fully backward compatible for existing consumers.

### Why

langchain-core standardizes finer-grained token breakdowns on `UsageMetadata` — `input_token_details` (e.g. `cache_read`, `cache_creation`) and `output_token_details` (e.g. `reasoning`). The wire `UsageInfo` only declared the flat counts, so langchain-core's v3 streaming compat bridge had to either drop those details or carry them as untyped keys behind a `cast`.

Dropping them is a real bug: providers fold cached tokens into `input_tokens` and break them out in `input_token_details`, so tracers (e.g. LangSmith) price every input token at the uncached rate when the details are lost — inflating reported cost for prompt-cached runs. See langchain-ai/langchain#38021, which currently works around this with a local `UsageInfo` subclass in core. With these fields on the shared type, core can drop the subclass and import `UsageInfo` directly.

### Generated bindings

`streaming/protocol.cddl` is the source of truth; `py/langchain_protocol/protocol.py` and `js/protocol.ts` are regenerated via `pnpm run compile`. The snake_case field names in the generated Python (`cache_creation`, `cache_read`, `audio`, `reasoning`) line up exactly with langchain-core's `InputTokenDetails` / `OutputTokenDetails`.

Bumps `langchain-protocol` `0.0.16` → `0.0.17`.

---

