### PR TITLE
feat(protocol): allow update and goto on input.respond

### DIFF
--- a/streaming/README.md
+++ b/streaming/README.md
@@ -312,6 +312,14 @@ The `input` channel carries human-in-the-loop requests. An `input.requested`
 event contains an `interruptId` and application-defined `payload`. Clients
 answer with `input.respond`, passing the same namespace and interrupt ID.
 
+`input.respond` may also carry optional `update` and `goto` fields. The server
+applies them as a LangGraph `Command(resume, update, goto)` in the same
+superstep as the resume, so the resumed run produces a single checkpoint that
+reflects the resume value, the state update, and the directed jump atomically.
+`update` lets a client push state (for example, an interrupt card message)
+alongside the resume without a separate state write; `goto` redirects the graph
+to a node name or `Send(node, input)` target as part of the same resume.
+
 ### `values`
 
 The `values` channel carries full graph state snapshots. When a subscription is

--- a/streaming/js/package.json
+++ b/streaming/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/protocol",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "TypeScript bindings for the LangChain agent streaming protocol",
   "license": "MIT",
   "keywords": [

--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -856,14 +856,37 @@ export interface InputRespond {
   params: InputRespondParams;
 }
 
-// Single-interrupt resume.
+// A directed jump applied alongside a resume, mapped to LangGraph's
+// Command(goto=...). Either a target node name, a Send (a node plus the
+// per-send input handed to it), or a list mixing the two for fan-out.
 export type InputRespondParams = InputRespondOne | InputRespondMany;
+
+export interface RunSend {
+  /**
+   * Target graph node
+   */
+  node: string;
+  /**
+   * Per-send input passed to the node
+   */
+  input?: any;
+}
+
+export type Goto = string | RunSend | (string | RunSend)[];
 
 // Batch resume — one entry per interrupt, resumed in a single run.
 export interface InputRespondOne {
   namespace: Namespace;
   interrupt_id: string;
   response: any;
+  /**
+   * State update applied in the same superstep as the resume (LangGraph Command(update=...))
+   */
+  update?: Record<string, any>;
+  /**
+   * Directed jump applied in the same superstep as the resume (LangGraph Command(goto=...))
+   */
+  goto?: Goto;
   /**
    * Per-run config overrides
    */
@@ -876,6 +899,14 @@ export interface InputRespondOne {
 
 export interface InputRespondMany {
   responses: InputRespondEntry[];
+  /**
+   * State update applied in the same superstep as the resume (LangGraph Command(update=...))
+   */
+  update?: Record<string, any>;
+  /**
+   * Directed jump applied in the same superstep as the resume (LangGraph Command(goto=...))
+   */
+  goto?: Goto;
   /**
    * Per-run config overrides
    */

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -964,11 +964,23 @@ input.respond = {
 ; respond to.
 InputRespondParams = InputRespondOne / InputRespondMany
 
+; A directed jump applied alongside a resume, mapped to LangGraph's
+; Command(goto=...). Either a target node name, a Send (a node plus the
+; per-send input handed to it), or a list mixing the two for fan-out.
+RunSend = {
+  node: text,                            ; Target graph node
+  ? input: any,                          ; Per-send input passed to the node
+}
+
+Goto = text / RunSend / [* (text / RunSend)]
+
 ; Single-interrupt resume.
 InputRespondOne = {
   namespace: Namespace,
   interruptId: text,
   response: any,
+  ? update: {* text => any},             ; State update applied in the same superstep as the resume (LangGraph Command(update=...))
+  ? goto: Goto,                          ; Directed jump applied in the same superstep as the resume (LangGraph Command(goto=...))
   ? config: {* text => any},             ; Per-run config overrides
   ? metadata: {* text => any},           ; Per-run metadata
 }
@@ -976,6 +988,8 @@ InputRespondOne = {
 ; Batch resume — one entry per interrupt, resumed in a single run.
 InputRespondMany = {
   responses: [+ InputRespondEntry],
+  ? update: {* text => any},             ; State update applied in the same superstep as the resume (LangGraph Command(update=...))
+  ? goto: Goto,                          ; Directed jump applied in the same superstep as the resume (LangGraph Command(goto=...))
   ? config: {* text => any},             ; Per-run config overrides
   ? metadata: {* text => any},           ; Per-run metadata
 }

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -515,15 +515,25 @@ class InputRespondOne(TypedDict):
     namespace: Namespace
     interrupt_id: str
     response: Any
+    update: NotRequired[dict[str, Any]]  # State update applied in the same superstep as the resume (LangGraph Command(update=...))
+    goto: NotRequired[Goto]  # Directed jump applied in the same superstep as the resume (LangGraph Command(goto=...))
     config: NotRequired[dict[str, Any]]  # Per-run config overrides
     metadata: NotRequired[dict[str, Any]]  # Per-run metadata
 
 class InputRespondMany(TypedDict):
     responses: list[InputRespondEntry]
+    update: NotRequired[dict[str, Any]]  # State update applied in the same superstep as the resume (LangGraph Command(update=...))
+    goto: NotRequired[Goto]  # Directed jump applied in the same superstep as the resume (LangGraph Command(goto=...))
     config: NotRequired[dict[str, Any]]  # Per-run config overrides
     metadata: NotRequired[dict[str, Any]]  # Per-run metadata
 
 InputRespondParams = Union[InputRespondOne, InputRespondMany]
+
+class RunSend(TypedDict):
+    node: str  # Target graph node
+    input: NotRequired[Any]  # Per-send input passed to the node
+
+Goto = Union[str, RunSend, list[Union[str, RunSend]]]
 
 class InputRespondEntry(TypedDict):
     namespace: Namespace

--- a/streaming/py/pyproject.toml
+++ b/streaming/py/pyproject.toml
@@ -7,7 +7,7 @@ name = "langchain-protocol"
 description = "Python bindings for the LangChain agent streaming protocol"
 license = { text = "MIT" }
 readme = "README.md"
-version = "0.0.16"
+version = "0.0.17"
 requires-python = ">=3.10.0,<4.0.0"
 classifiers = [
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary
- Add optional `update` (state mutation) and `goto` (directed jump) fields to `InputRespondOne` and `InputRespondMany` in `streaming/protocol.cddl`, plus a small `RunSend`/`Goto` type for the goto target.
- The server is expected to fold these into a single LangGraph `Command(resume, update, goto)`, so a resumed run produces one checkpoint reflecting the resume value, the state update, and the jump atomically — no separate `state.update` round-trip and no intermediate flicker.
- Regenerate the `js/` and `py/` bindings from the CDDL and document the new fields in the `input` channel section of the README.
