### PR TITLE
fix: bump stale openapi.json info.version 0.1.6 → 0.2.0 (#60)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Agent Protocol",
-    "version": "0.1.6"
+    "version": "0.2.0"
   },
   "tags": [
     {


### PR DESCRIPTION
## What

Fixes #60 — `openapi.json`'s `info.version` has been frozen at `0.1.6` while the
API moved on. The `/runs` endpoint consolidation that #60 references shipped with
0.2.0 and is already present in the current spec, but the version string was never
bumped. The Scalar API docs page (`api.html`) renders `info.version`, so the
published docs currently show the wrong version.

## What changed

A single line in `openapi.json`:

```diff
-    "version": "0.1.6"
+    "version": "0.2.0"
```

Nothing else.

## Why 0.2.0

This matches the causal story in #60 and the commit (`59338b3`, "Small fixes for
0.2.0") that landed the `/runs` consolidation. Happy to target `0.2.1` instead —
the latest tag — if you'd prefer the newest tagged version; just say the word. I
avoided inventing a fresh `0.3.0` so this stays a pure metadata correction and
doesn't imply a new release cut.

## Verification

- Valid JSON (`json.load` parses cleanly), and `prettier --write openapi.json`
  produces zero diff (stays formatter-clean).
- No CI in the repo validates/lints the spec; no runtime contract change.

Thanks to the #60 reporter for catching this.
