### PR TITLE
docs: fix incorrect project name and placeholder values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Agent Protocol
 
-👋 Hi there! Thank you for being interested in contributing to LangGraph.
+👋 Hi there! Thank you for being interested in contributing to Agent Protocol.
 As an open source project in a rapidly developing field, we are extremely open
 to contributions, whether it be in the form of a new feature, improved infra, or better documentation.
 

--- a/client-python/README.md
+++ b/client-python/README.md
@@ -18,9 +18,9 @@ Python 3.9+
 If the python package is hosted on a repository, you can install directly using:
 
 ```sh
-pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
+pip install git+https://github.com/langchain-ai/agent-protocol.git
 ```
-(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git`)
+(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/langchain-ai/agent-protocol.git`)
 
 Then import the package:
 ```python

--- a/client-python/pyproject.toml
+++ b/client-python/pyproject.toml
@@ -5,7 +5,7 @@ description = "Agent Protocol"
 authors = ["OpenAPI Generator Community <team@openapitools.org>"]
 license = "NoLicense"
 readme = "README.md"
-repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+repository = "https://github.com/langchain-ai/agent-protocol"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Agent Protocol"]
 include = ["ap_client/py.typed"]
 


### PR DESCRIPTION
## Summary

- Fix CONTRIBUTING.md line 3: references 'LangGraph' instead of 'Agent Protocol'
- Fix client-python/README.md: replace `GIT_USER_ID/GIT_REPO_ID` placeholders with `langchain-ai/agent-protocol`
- Fix client-python/pyproject.toml: update repository URL from placeholder to actual GitHub URL

## Testing

All changes are documentation/metadata fixes. Verified placeholders exist via grep.