### PR TITLE
feat: add LangSmith routing to run start

### DIFF
--- a/streaming/js/protocol.ts
+++ b/streaming/js/protocol.ts
@@ -380,6 +380,17 @@ export interface RunStart {
   params: RunStartParams;
 }
 
+export interface LangSmithTracer {
+  /**
+   * Additional LangSmith project receiving the trace
+   */
+  project_name?: string;
+  /**
+   * LangSmith dataset example associated with the trace
+   */
+  example_id?: string;
+}
+
 export interface RunStartParams {
   /**
    * Deployed graph/agent to run
@@ -397,6 +408,10 @@ export interface RunStartParams {
    * Per-run metadata
    */
   metadata?: Record<string, any>;
+  /**
+   * Optional additional LangSmith trace destination
+   */
+  langsmith_tracer?: LangSmithTracer;
 }
 
 // ==========================================================================

--- a/streaming/protocol.cddl
+++ b/streaming/protocol.cddl
@@ -465,11 +465,17 @@ run.start = {
   params: RunStartParams,
 }
 
+LangSmithTracer = {
+  ? projectName: text,                   ; Additional LangSmith project receiving the trace
+  ? exampleId: text,                     ; LangSmith dataset example associated with the trace
+}
+
 RunStartParams = {
   assistantId: text,                     ; Deployed graph/agent to run
   input: any,                            ; Graph input, resume value, or injected message
   ? config: {* text => any},             ; Per-run config overrides
   ? metadata: {* text => any},           ; Per-run metadata
+  ? langsmithTracer: LangSmithTracer,    ; Optional additional LangSmith trace destination
 }
 
 RunResult = {

--- a/streaming/py/langchain_protocol/protocol.py
+++ b/streaming/py/langchain_protocol/protocol.py
@@ -375,11 +375,16 @@ RunCommand = RunStart
 class _CommandVariant0(_CommandFields, RunCommand):
     pass
 
+class LangSmithTracer(TypedDict):
+    project_name: NotRequired[str]  # Additional LangSmith project receiving the trace
+    example_id: NotRequired[str]  # LangSmith dataset example associated with the trace
+
 class RunStartParams(TypedDict):
     assistant_id: str  # Deployed graph/agent to run
     input: Any  # Graph input, resume value, or injected message
     config: NotRequired[dict[str, Any]]  # Per-run config overrides
     metadata: NotRequired[dict[str, Any]]  # Per-run metadata
+    langsmith_tracer: NotRequired[LangSmithTracer]  # Optional additional LangSmith trace destination
 
 Channel = Union[Literal["values"], Literal["updates"], Literal["messages"], Literal["tools"], Literal["lifecycle"], Literal["input"], Literal["checkpoints"], Literal["tasks"], Literal["custom"], Annotated[str, "custom:.+"]]
 


### PR DESCRIPTION
## Description
Add optional LangSmith tracer settings to the thread-stream `run.start` protocol so clients can select an additional trace project per run.

## Release Note
Thread-stream run starts can route traces to an additional LangSmith project.

## Test Plan
- [x] Regenerate Python and TypeScript bindings and validate CDDL

## Related PRs
- langchain-ai/langgraph#8723
- langchain-ai/langgraphjs#2745
- langchain-ai/langgraph-api#4033

Made by [Open SWE](https://openswe.vercel.app/agents/f9e34294-b9c3-52f0-815a-0102188e1181)